### PR TITLE
Corrections to the computation of the Hessian necessary for the computation of the Normalization of a model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+NOTE: This a a form of bat (https://github.com/bat/bat) for the implementation of MPI. The branch "bat" will be kept vanilla. The release branches will be modified for the MPI implementation.
+
 BAT - Bayesian Analysis Toolkit
 ===============================
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-NOTE: This a a form of bat (https://github.com/bat/bat) for the implementation of MPI. The branch "bat" will be kept vanilla. The release branches will be modified for the MPI implementation.
+NOTE: This a a form of bat (https://github.com/bat/bat) for the implementation of MPI. The master branch will be kept vanilla. The release branches will be modified for the MPI implementation.
 
 BAT - Bayesian Analysis Toolkit
 ===============================

--- a/src/BCModel.cxx
+++ b/src/BCModel.cxx
@@ -533,10 +533,10 @@ double BCModel::HessianMatrixElement(const BCParameter * par1, const BCParameter
    xmm[idx2] -= dx2;
 
    // calculate probability at these points
-   double ppp = Likelihood(xpp);
-   double ppm = Likelihood(xpm);
-   double pmp = Likelihood(xmp);
-   double pmm = Likelihood(xmm);
+   double ppp = LogLikelihood(xpp) + LogAPrioriProbability(xpp);
+   double ppm = LogLikelihood(xpm) + LogAPrioriProbability(xpm);
+   double pmp = LogLikelihood(xmp) + LogAPrioriProbability(xmp);
+   double pmm = LogLikelihood(xmm) + LogAPrioriProbability(xmm);
 
    // return derivative
    return (ppp + pmm - ppm - pmp) / (4. * dx1 * dx2);


### PR DESCRIPTION
Modification to the Hessian Matrix computation according to the definition in:

Lewis, S. M., & Raftery, A. E. (1997). Estimating Bayes Factors via Posterior Simulation With the Laplace-Metropolis Estimator.
Journal of the American Statistical Association, 92(438), 648–655. doi:10.2307/2965712

Likelihood(x) - > LogLikelihood(x) + LogAPrioriProbability(x) in lines 536 to 539 in BCModel.cxx

This version of BCModel.cxx does not have any MPI modifications. 