### PR TITLE
[format] Exclude *rdict.cxx from formatting

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,6 +97,7 @@ install-data-hook:
 	@echo "   ============================================================"
 	@echo
 
+# format all C++ source files except root dictionaries as they are messed up
 .PHONY: format
 format:
-	astyle --options=tools/astylerc --formatted `find BAT/ benchmarks/ examples/ tools $(SUBDIRS) -name '*.C' -o -name '*.cxx' -o -name '*.h'`
+	astyle --options=tools/astylerc --formatted `find BAT/ benchmarks/ examples/ tools $(SUBDIRS) -name '*.C' -o \( -name '*.cxx' ! -name '*rdict.cxx' \) -o -name '*.h'`


### PR DESCRIPTION
If they are formatted with astyle, subsequent builds fail on my machine