### PR TITLE
[configure,install] Enable roostats by default

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ Platforms
 
 BAT has been developed on Linux machines running different
 distributions and different versions of the kernel and gcc. As far as
-we know there is nothing distribution dependent inside of BAT. A gcc
+we know there is nothing distribution-dependent inside of BAT. A gcc
 version >4.2 should suffice to compile the C++ code.
 
 The installation and functionality of BAT has also been tested on MAC OS X.
@@ -22,9 +22,8 @@ Dependencies
 ### Required: ROOT
 
 ROOT is an object-oriented data-analysis framework. You can obtain it
-from http://root.cern.ch/. Since BAT version 0.4.2 a ROOT version 5.22
-or later is needed to compile and run BAT. ROOT 6 is supported as
-well.
+from http://root.cern.ch/. For BAT version 1.0, a ROOT version 5.27/04
+or later is needed to compile. ROOT 6 is supported as well.
 
 Please check your Linux distribution for the availability of
 precompiled packages on your system. Many distributions offer the ROOT
@@ -100,10 +99,10 @@ The configure script checks for ROOT availability in the system and
 fails if ROOT is not installed. You can specify the `ROOTSYS` directory
 using `--with-rootsys=/path/to/rootsys`
 
-You can configure BAT with the RooFit/RooStats support using
-`--enable-roostats`. The configure script will check whether the version of
-ROOT is sufficient and whether the ROOT was compiled with RooFit/RooStats
-support.
+BAT support for RooFit/RooStats is turned on by default. The configure
+script will check whether the version of ROOT is sufficient and
+whether ROOT was compiled with RooFit/RooStats support. The feature
+can be turned off explicitly with `--disable-roostats`.
 
 ### openMP
 
@@ -116,6 +115,8 @@ implementation dependent and may also depend on the current load of
 the CPU. Manual control over the number of threads is achieved
 entirely by openMP means such as setting the environment variable
 `OMP_NUM_THREADS` before running an executable.
+
+The default version of clang does not implement openMP.
 
 ### Cuba
 

--- a/configure.ac
+++ b/configure.ac
@@ -298,18 +298,16 @@ AC_DEFUN(
 	[REQUIRE_ROOT_VERSION],
 	[require_ROOT_version=$1]
 )
-REQUIRE_ROOT_VERSION([5.22])
+REQUIRE_ROOT_VERSION([5.27.04])
 
 dnl RooStats
 AC_ARG_ENABLE(
 	[roostats],
-	[AS_HELP_STRING([--enable-roostats],[compile with RooStats support (default no)])],
+	[AS_HELP_STRING([--disable-roostats],[compile with RooStats support (default yes if available)])],
 	[
-		use_roostats=yes
-		REQUIRE_ROOT_VERSION([5.27.04])
-		echo "compiling with RooStats support: required ROOT version $require_ROOT_version or later"
+		use_roostats=${enable_val}
 	],
-	[use_roostats=no]
+	[use_roostats=yes]
 )
 dnl ROOT
 m4_include(tools/build/root.m4)
@@ -326,7 +324,10 @@ ROOT_PATH(
 dnl add some libraries to set of basic root libraries
 ROOTLIBS="$ROOTLIBS -lMinuit"
 
-dnl mathmore is a requirement of roostats
+dnl mathmore is a requirement of roostats and allows us to use
+dnl features from the GSL. The check is done again inside HAS_ROOSTATS
+dnl but we can't get that result. So the output `checking whether ROOT
+dnl is compiled with MathMore support... ` can appear twice. Not big deal.
 AC_MSG_CHECKING(whether ROOT is compiled with MathMore support)
 hasmathmore=`$ROOTCONF --has-mathmore`
 AC_MSG_RESULT($hasmathmore)
@@ -335,11 +336,11 @@ AM_CONDITIONAL([ROOTMATHMORE], [test x$hasmathmore = xyes])
 dnl RooFit
 if test $use_roostats = yes; then
 	HAS_ROOSTATS(
-		,
+		AC_MSG_RESULT([Compiling BAT with RooStats support.]),
 		[
-			AC_MSG_ERROR([ROOT was compiled without RooFit support.
-				Recompile ROOT or provide path to different version.])
-			AC_MSG_ERROR([Compiling BAT without RooStats support.])
+			AC_MSG_RESULT([ROOT was compiled without RooFit support.])
+			AC_MSG_RESULT([To add RooStats support, recompile ROOT or provide path to different version.])
+			AC_MSG_RESULT([Compiling BAT without RooStats support.])
 			use_roostats=no
 		]
 	)


### PR DESCRIPTION
fixes #76

* configure doesn't fail if roostats is unavailable but reports whether
  it is used
* bump min. root version to 5.27/04. This is what we claimed roostats
requires. I haven't tested this. In any case that is outdated
* update install instructions, including clang's missing support for openmp

Note: All my available root versions have roostats so I checked that things work fine if it's not available by removing the feature `roofit` from `root-config`.