### PR TITLE
[BCModel] Check logPrior before calculating logLikelihood

### DIFF
--- a/src/BCModel.cxx
+++ b/src/BCModel.cxx
@@ -85,8 +85,11 @@ void swap(BCModel& A, BCModel& B)
 // ---------------------------------------------------------
 double BCModel::LogProbabilityNN(const std::vector<double>& parameters)
 {
-    double ll = LogLikelihood(parameters);
+    // first calculate prior (which is usually cheaper than likelihood)
     double lp = LogAPrioriProbability(parameters);
+    // then calculation likelihood, or set to -inf, if prior already invalid
+    double ll = (std::isfinite(lp)) ? LogLikelihood(parameters) : -std::numeric_limits<double>::infinity();;
+
     if (MCMCGetCurrentChain() < fMCMCLogLikelihood_Provisional.size() and MCMCGetCurrentChain() < fMCMCLogPrior_Provisional.size()) {
         fMCMCLogLikelihood_Provisional[MCMCGetCurrentChain()] = ll;
         fMCMCLogPrior_Provisional[MCMCGetCurrentChain()] = lp;


### PR DESCRIPTION
We currently calculate the LogLikelihood (often expensive), then calculate the LogPrior (often cheap). It makes more sense to first calculate the LogPrior; if this returns an invalid (not finite) value, the LogLikelihood is not evaluated, and is set simply to -infinity. (We could also have NaN, if prefered.)