### PR TITLE
[BCEngine] MCMC[User]Initialize() throws exceptions

### DIFF
--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -1288,22 +1288,23 @@ public:
     static double RValue(std::vector<double> means, std::vector<double> variances, unsigned n, bool correctForSamplingVariability = true);
 
     /**
-     * Resets all containers used in MCMC and initializes starting points.
-     * @return Success of action. */
-    bool MCMCInitialize();
+     * Resets all containers used in MCMC and initializes starting points. */
+    void MCMCInitialize();
 
     /**
      * User hook called from MCMCInitialize().
      *
      * MCMCUserInitialize() is called after all settings for the
-     * upcoming MCMC run are fixed. This is useful for the user, for
-     * example, to allocate separate copies of objects within the user
-     * model, one for each chain for thread safety. The user
-     * likelihood is only called after MCMCUserInitialize() returns.
+     * upcoming MCMC run are fixed but before the initial point is
+     * chosen and before any call to user methods such as
+     * LogLikelihood() or LogAPrioriProbability() are
+     * issued. MCMCUserInitialize() is useful for example to allocate
+     * separate copies of objects within the user model, one per
+     * chain, for thread safety.
      *
-     * @return Success of action. */
-    virtual bool MCMCUserInitialize()
-    { return true; }
+     * @note Any error inside MCMCUserInitialize() should be signaled via an exception. */
+    virtual void MCMCUserInitialize()
+    {}
 
     /**
      * Reset the MCMC variables. */

--- a/examples/advanced/polynomialFit/PolAsymm.h
+++ b/examples/advanced/polynomialFit/PolAsymm.h
@@ -27,20 +27,14 @@ public:
     { return false; }
 
     // necessary to overload pure virtual BCFitter function
-    virtual void DrawFit(const char* options, bool flaglegend = false)
-    { }
+    void DrawFit(const char* options, bool flaglegend = false)
+    {}
 
     // fit function returning expectation value for each data point
     virtual double FitFunction(double* x, double* par);
 
     // loglikelihood function - probability of the data given the parameters
-    virtual double LogLikelihood(const std::vector<double>& par);
-
-    // this likelihood is thread safe, so there is nothing to do
-    virtual bool MCMCUserInitialize()
-    {
-        return true;
-    }
+    double LogLikelihood(const std::vector<double>& par);
 };
 
 #endif

--- a/models/base/BCFitter.cxx
+++ b/models/base/BCFitter.cxx
@@ -23,6 +23,8 @@
 #include <TH1D.h>
 #include <TH2D.h>
 
+#include <stdexcept>
+
 // due to a bug in root, the normalization member is not copied in the
 // TF1 copy ctor and gets a random initialization that can be `true`
 // giving rise to a lot of useless integrals. Copy manually in root
@@ -77,7 +79,7 @@ BCFitter::~BCFitter()
 }
 
 // ---------------------------------------------------------
-bool BCFitter::MCMCUserInitialize()
+void BCFitter::MCMCUserInitialize()
 {
     // add or remove copies
     fFitFunction.resize(fMCMCNChains, fFitFunction.front());
@@ -88,8 +90,6 @@ bool BCFitter::MCMCUserInitialize()
     for (unsigned i = 0; i < fFitFunction.size(); ++i)
         fFitFunction[i].SetNormalized(fFitFunction.front().IsEvalNormalized());
 #endif
-
-    return true;
 }
 
 // ---------------------------------------------------------

--- a/models/base/BCFitter.h
+++ b/models/base/BCFitter.h
@@ -182,7 +182,7 @@ public:
 
     /**
      * Create enough TF1 copies for thread safety */
-    virtual bool MCMCUserInitialize();
+    virtual void MCMCUserInitialize();
 
 private:
     /** Fit function (as vector for thread safety) */


### PR DESCRIPTION
Now errors can't be ignored anymore and the chain doesn't run, avoiding hard-to-find segfaults.

Resolves #91 