### PR TITLE
Properly calling bat-config in the MakefileTemplate.in used by bat-pr…

### DIFF
--- a/tools/MakefileTemplate.in
+++ b/tools/MakefileTemplate.in
@@ -35,8 +35,8 @@ LDFLAGS   = -g -O2 @LDFLAGS@
 # available in $PATH. If BAT is not installed in the standard system
 # directories, update $PATH accordingly.
 
-CXXFLAGS += `bat-config --cflags`
-LIBS := `bat-config --libs`
+CXXFLAGS += $(shell bat-config --cflags)
+LIBS := $(shell bat-config --libs)
 
 # ----------------------------------------------------------------------
 # don't change lines below unless you know what you're doing


### PR DESCRIPTION
Addressing issue #105 

Apparently this the only remaining call to `bat-config`, since @oschulz has changed the example makefile system. Easy peasy.