### PR TITLE
Fixed storing of fMCMCTree, at random beeing unreadable while writing [FAILS TESTS]

### DIFF
--- a/src/BCEngineMCMC.cxx
+++ b/src/BCEngineMCMC.cxx
@@ -1725,7 +1725,6 @@ bool BCEngineMCMC::MetropolisPreRun()
 
     // autosave every 10 checks
     if (fMCMCTree) {
-        fMCMCTree->SetAutoSave(10 * nIterationsPreRunCheck);
         fMCMCTree->AutoSave("SaveSelf");
     }
 
@@ -1915,7 +1914,9 @@ bool BCEngineMCMC::MetropolisPreRun()
                 }
             } // end convergence conditional
         } // end chains>1 conditional
-
+        if (nChecks%10==0){
+          fMCMCTree->AutoSave("SaveSelf");
+        }
         ++nChecks;              // increase number of checks made
 
         // scales have not been adjusted and convergence has been reached (or only one chain used)


### PR DESCRIPTION
TTree->SetAutoSave somehow conflicts with AutoSave("SaveSelf") and the tree becomes unreadable when writing

This fixed this issue
