### PR TITLE
[BCMath] Separate errors in LogPoisson for lambda == 0 and lambda < 0

### DIFF
--- a/src/BCMath.cxx
+++ b/src/BCMath.cxx
@@ -55,8 +55,13 @@ double BCMath::LogPoisson(double x, double lambda)
     if (x < 0)
         return -std::numeric_limits<double>::infinity();
 
-    if (lambda <= 0) {
-        BCLog::OutWarning("BCMath::LogPoisson : expectation value (lambda) cannot be negative!");
+    if (lambda == 0) {
+        BCLog::OutWarning("BCMath::LogPoisson : expectation value (lambda) cannot be zero.");
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    if (lambda < 0) {
+        BCLog::OutWarning("BCMath::LogPoisson : expectation value (lambda) cannot be negative.");
         return std::numeric_limits<double>::quiet_NaN();
     }
 


### PR DESCRIPTION
Address issue #157 