### PR TITLE
fixed issue with root directory ownership

### DIFF
--- a/src/BCHistogramBase.cxx
+++ b/src/BCHistogramBase.cxx
@@ -196,6 +196,7 @@ void BCHistogramBase::SetHistogram(const TH1* const hist)
 
     fHistogram = (TH1*) (hist->Clone(Form("%s_bch", hist->GetName())));
     fHistogram->SetStats(false);
+    fHistogram->SetDirectory(0);
     fDimension = fHistogram->GetDimension();
 
     // normalize; TO DO: replace with division of each bin by width/area for arbitrary binning


### PR DESCRIPTION
In case of an open TFile during instance creation, the TFile is the owner of the stored histogram, this is fixed by SetDirectory(0)