### PR TITLE
[BCConstantPrior] fixes bug in getting random point according to prior.

### DIFF
--- a/src/BCConstantPrior.cxx
+++ b/src/BCConstantPrior.cxx
@@ -92,7 +92,7 @@ double BCConstantPrior::GetRandomValue(double xmin, double xmax, TRandom* const 
 {
     if (!R)
         return std::numeric_limits<double>::quiet_NaN();
-    return xmin + R->Rndm() * xmax;
+    return xmin + R->Rndm() * (xmax - xmin);
 }
 
 


### PR DESCRIPTION
fixes bug in which random point is generated currently by: `min + rand * max`; instead of by: `min + rand * (max - min)`