### PR TITLE
Added errorband related function to BCFitter

### DIFF
--- a/models/base/BCFitter.cxx
+++ b/models/base/BCFitter.cxx
@@ -96,21 +96,21 @@ void BCFitter::MarginalizePreprocess()
     if (GetDataSet() && fFitFunctionIndexX >= 0 && fFitFunctionIndexY >= 0) {
 
         dx = (GetDataSet()->GetRangeWidth(fFitFunctionIndexX)
-                +fErrorBandExtensionLowEdgeX
-                +fErrorBandExtensionUpEdgeX) 
-                / fErrorBandNbinsX;
-                
-                
-        dy = (GetDataSet()->GetRangeWidth(fFitFunctionIndexY)
-        +fErrorBandExtensionLowEdgeY
-        +fErrorBandExtensionUpEdgeY)  / fErrorBandNbinsY;
+              + fErrorBandExtensionLowEdgeX
+              + fErrorBandExtensionUpEdgeX)
+             / fErrorBandNbinsX;
 
-        double xRangeLow=GetDataSet()->GetLowerBound(fFitFunctionIndexX)-fErrorBandExtensionLowEdgeX - dx / 2;
-        double xRangeHigh=GetDataSet()->GetUpperBound(fFitFunctionIndexX)+fErrorBandExtensionUpEdgeX + dx / 2;
-        
-        double yRangeLow=GetDataSet()->GetLowerBound(fFitFunctionIndexY)-fErrorBandExtensionLowEdgeY - dy / 2;
-        double yRangeHigh=GetDataSet()->GetUpperBound(fFitFunctionIndexY)+fErrorBandExtensionUpEdgeY + dy / 2;
-        
+
+        dy = (GetDataSet()->GetRangeWidth(fFitFunctionIndexY)
+              + fErrorBandExtensionLowEdgeY
+              + fErrorBandExtensionUpEdgeY)  / fErrorBandNbinsY;
+
+        double xRangeLow = GetDataSet()->GetLowerBound(fFitFunctionIndexX) - fErrorBandExtensionLowEdgeX - dx / 2;
+        double xRangeHigh = GetDataSet()->GetUpperBound(fFitFunctionIndexX) + fErrorBandExtensionUpEdgeX + dx / 2;
+
+        double yRangeLow = GetDataSet()->GetLowerBound(fFitFunctionIndexY) - fErrorBandExtensionLowEdgeY - dy / 2;
+        double yRangeHigh = GetDataSet()->GetUpperBound(fFitFunctionIndexY) + fErrorBandExtensionUpEdgeY + dy / 2;
+
         fErrorBandXY = TH2D(TString::Format("errorbandxy_%s", GetSafeName().data()), "",
                             fErrorBandNbinsX,
                             xRangeLow,
@@ -298,15 +298,6 @@ TH2* BCFitter::GetGraphicalErrorBandXY(double level, int nsmooth, bool overcover
 
     return hist_tempxy;
 }
-
-// ---------------------------------------------------------
-
-TH2 * BCFitter::GetErrorBandXYCopy() const
-{
-    TH2* hist=dynamic_cast<TH2*>( fErrorBandXY.Clone());
-    hist->SetDirectory(0);
-    return hist;
-};
 
 
 // ---------------------------------------------------------

--- a/models/base/BCFitter.h
+++ b/models/base/BCFitter.h
@@ -53,7 +53,9 @@ public:
     /**
      * Get fit function. */
     TF1& GetFitFunction()
-    { return fFitFunction.at(GetCurrentChain()); }
+    {
+        return fFitFunction.at(GetCurrentChain());
+    }
 
     /**
      * @param level Desired probability mass
@@ -61,10 +63,13 @@ public:
      * @param overcoverage Flag for whether to overcover desired probability mass.
      * @return A 2D histogram of the smallest interval in Y for each bin in X containing the desired probability mass. */
     TH2* GetGraphicalErrorBandXY(double level = .68, int nsmooth = 0, bool overcoverage = true) const;
-    
-    //* @return A copy of the internal errorband histogram
-    TH2* GetErrorBandXYCopy()const;
-        
+
+    //* @return A const reference of the internal errorband histogram
+    const TH2& GetErrorBandXY()const
+    {
+        return fErrorBandXY;
+    };
+
     /**
      * Returns a vector of y-values at a certain probability level.
      * @param level The level of probability
@@ -76,7 +81,9 @@ public:
     TGraph* GetFitFunctionGraph(const std::vector<double>& parameters);
 
     TGraph* GetFitFunctionGraph()
-    { return GetFitFunctionGraph(std::vector<double>(GetBestFitParameters().begin(), GetBestFitParameters().begin() + GetNParameters())); }
+    {
+        return GetFitFunctionGraph(std::vector<double>(GetBestFitParameters().begin(), GetBestFitParameters().begin() + GetNParameters()));
+    }
 
     TGraph* GetFitFunctionGraph(const std::vector<double>& parameters, double xmin, double xmax, int n = 1000);
 
@@ -85,7 +92,9 @@ public:
     bool GetFixedDataAxis(unsigned int index) const;
 
     double GetPValue() const
-    { return fPValue; }
+    {
+        return fPValue;
+    }
 
     /* @} */
 
@@ -95,45 +104,65 @@ public:
     /**
      * Sets the error band flag to continuous function */
     void SetErrorBandContinuous(bool flag);
-    
+
     /**
      *Extends the lower x Edge of th errorband by -extension */
-    void SetErrorBandExtensionLowEdgeX(double extension){fErrorBandExtensionLowEdgeX=extension;}
-    
+    void SetErrorBandExtensionLowEdgeX(double extension)
+    {
+        fErrorBandExtensionLowEdgeX = extension;
+    }
+
     /**
      *Extends the lower x Edge of th errorband by +extension */
-    void SetErrorBandExtensionUpEdgeX(double extension){fErrorBandExtensionUpEdgeX=extension;}
-    
+    void SetErrorBandExtensionUpEdgeX(double extension)
+    {
+        fErrorBandExtensionUpEdgeX = extension;
+    }
+
     /**
      *Extends the lower y Edge of th errorband by -extension */
-    void SetErrorBandExtensionLowEdgeY(double extension){fErrorBandExtensionLowEdgeY=extension;}
-    
+    void SetErrorBandExtensionLowEdgeY(double extension)
+    {
+        fErrorBandExtensionLowEdgeY = extension;
+    }
+
     /**
      *Extends the lower y Edge of th errorband by +extension */
-    void SetErrorBandExtensionUpEdgeY(double extension){fErrorBandExtensionUpEdgeY=extension;}
+    void SetErrorBandExtensionUpEdgeY(double extension)
+    {
+        fErrorBandExtensionUpEdgeY = extension;
+    }
     /**
      * Turn on or off the filling of the error band during the MCMC run.
      * @param flag set to true for turning on the filling */
     void SetFillErrorBand(bool flag = true)
-    { fFlagFillErrorBand = flag; }
+    {
+        fFlagFillErrorBand = flag;
+    }
 
     /**
      * Turn off filling of the error band during the MCMC run.
      * This method is equivalent to SetFillErrorBand(false) */
     void UnsetFillErrorBand()
-    { fFlagFillErrorBand = false; }
+    {
+        fFlagFillErrorBand = false;
+    }
 
     /**
      * Sets index of the x values in function fits.
      * @param index Index of the x values */
     void SetFitFunctionIndexX(int index)
-    { fFitFunctionIndexX = index; }
+    {
+        fFitFunctionIndexX = index;
+    }
 
     /**
      * Sets index of the y values in function fits.
      * @param index Index of the y values */
     void SetFitFunctionIndexY(int index)
-    { fFitFunctionIndexY = index; }
+    {
+        fFitFunctionIndexY = index;
+    }
 
     /**
      * Sets indices of the x and y values in function fits.
@@ -150,7 +179,9 @@ public:
      * true: use ROOT's TF1::Integrate() \n
      * false: use linear interpolation */
     void SetFlagIntegration(bool flag)
-    { fFlagIntegration = flag; };
+    {
+        fFlagIntegration = flag;
+    };
 
     /**
      * Defines a fit function.
@@ -253,18 +284,18 @@ protected:
 
     /** Storage for plot objects with proper clean-up */
     mutable BCAux::BCTrash<TObject> fObjectTrash;
-    
+
     /**
      * extends the lower edge of x range by the given value  */
     double fErrorBandExtensionLowEdgeX;
     /**
      * extends the upper edge of x range by the given value  */
     double fErrorBandExtensionUpEdgeX;
-    
+
     /**
      * extends the upper edge of y range by the given value  */
     double fErrorBandExtensionLowEdgeY;
-    
+
     /**
      * extends the upper edge of y range by the given value  */
     double fErrorBandExtensionUpEdgeY;

--- a/models/base/BCFitter.h
+++ b/models/base/BCFitter.h
@@ -61,7 +61,10 @@ public:
      * @param overcoverage Flag for whether to overcover desired probability mass.
      * @return A 2D histogram of the smallest interval in Y for each bin in X containing the desired probability mass. */
     TH2* GetGraphicalErrorBandXY(double level = .68, int nsmooth = 0, bool overcoverage = true) const;
-
+    
+    //* @return A copy of the internal errorband histogram
+    TH2* GetErrorBandXYCopy()const;
+        
     /**
      * Returns a vector of y-values at a certain probability level.
      * @param level The level of probability
@@ -92,7 +95,22 @@ public:
     /**
      * Sets the error band flag to continuous function */
     void SetErrorBandContinuous(bool flag);
-
+    
+    /**
+     *Extends the lower x Edge of th errorband by -extension */
+    void SetErrorBandExtensionLowEdgeX(double extension){fErrorBandExtensionLowEdgeX=extension;}
+    
+    /**
+     *Extends the lower x Edge of th errorband by +extension */
+    void SetErrorBandExtensionUpEdgeX(double extension){fErrorBandExtensionUpEdgeX=extension;}
+    
+    /**
+     *Extends the lower y Edge of th errorband by -extension */
+    void SetErrorBandExtensionLowEdgeY(double extension){fErrorBandExtensionLowEdgeY=extension;}
+    
+    /**
+     *Extends the lower y Edge of th errorband by +extension */
+    void SetErrorBandExtensionUpEdgeY(double extension){fErrorBandExtensionUpEdgeY=extension;}
     /**
      * Turn on or off the filling of the error band during the MCMC run.
      * @param flag set to true for turning on the filling */
@@ -235,6 +253,21 @@ protected:
 
     /** Storage for plot objects with proper clean-up */
     mutable BCAux::BCTrash<TObject> fObjectTrash;
+    
+    /**
+     * extends the lower edge of x range by the given value  */
+    double fErrorBandExtensionLowEdgeX;
+    /**
+     * extends the upper edge of x range by the given value  */
+    double fErrorBandExtensionUpEdgeX;
+    
+    /**
+     * extends the upper edge of y range by the given value  */
+    double fErrorBandExtensionLowEdgeY;
+    
+    /**
+     * extends the upper edge of y range by the given value  */
+    double fErrorBandExtensionUpEdgeY;
 
     /** Don't allow user to accidentally set the data set,
      * as it is used internally. */


### PR DESCRIPTION
Added the possibility to extend the errorband in Y and X range to cover cases in which the needed x or y range is higher than	 the default errorband range. One Example could be a calibration which has to be evaluated beyond the highest x point.

Added a function which returns a copy of the internal errorband histogram. In this case one could store it for later usage.
