### PR TITLE
Fix for fixed parameters in Minuit

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -8,6 +8,7 @@
 # Binaries
 asymmErrorsFitterExample
 ensembletest
+readRootOutput
 runAnomCouplings
 runCombineGaussians
 runCombination

--- a/src/BCIntegrate.cxx
+++ b/src/BCIntegrate.cxx
@@ -107,15 +107,20 @@ void Wrapper::Init(const std::vector<double>& start, int printlevel)
 
     for (unsigned i = 0; i < adapt.m->GetNParameters(); ++i) {
         const BCParameter& p = adapt.m->GetParameter(i);
-        const bool success = min.SetLimitedVariable(i, p.GetName(),
-                             newstart.at(i),
-                             p.GetRangeWidth() / 100.,
-                             p.GetLowerLimit(), p.GetUpperLimit());
-        if (!success) {
-            BCLOG_ERROR(std::string("Can't add parameter ") + ToString(i) + std::string(" to minuit"));
-        }
-        if (p.Fixed() && !(min.SetVariableValue(i, p.GetFixedValue()) && min.FixVariable(i)))  {
-            BCLOG_ERROR(std::string("Cannot fix parameter ") + ToString(i) + " in minuit");
+        if (p.Fixed()) {
+            const bool success = min.SetFixedVariable(i, p.GetName(),
+                                 newstart.at(i));
+            if (!success) {
+                BCLOG_ERROR(std::string("Cannot add fixed parameter ") + ToString(i) + " to minuit");
+            }
+        } else {
+            const bool success = min.SetLimitedVariable(i, p.GetName(),
+                                 newstart.at(i),
+                                 p.GetRangeWidth() / 100.,
+                                 p.GetLowerLimit(), p.GetUpperLimit());
+            if (!success) {
+                BCLOG_ERROR(std::string("Cannot add parameter ") + ToString(i) + " to minuit");
+            }
         }
     }
 }

--- a/src/BCLog.cxx
+++ b/src/BCLog.cxx
@@ -87,7 +87,7 @@ void BCLog::StartupInfo()
     const char* message = Form(
                               " +------------------------------------------------------+\n"
                               " |                                                      |\n"
-                              " | BAT version %7s                                  |\n"
+                              " | BAT version %-12s                             |\n"
                               " | Copyright (C) 2007-2015, the BAT core developer team |\n"
                               " | All rights reserved.                                 |\n"
                               " |                                                      |\n"


### PR DESCRIPTION
If a parameter like
```
BCParameter a("a", 0., 1.);
a.Fix(0.);
```
is added in BAT, using `FindModeMinuit` will return a result in which this parameter no longer is zero. Currently BAT adds a limited variable to Minuit for each parameter, and then fixes this variable to its value if the parameter is fixed. But Minuit (at least the version used by BAT) does not allow a variable at one of its limits, but instead always moves the variable into its fit range. Fixing the variable then fixes it to the shifted value. The fix is to add a fixed variable from the beginning.

Add additional watchers: @pdigiglio