### PR TITLE
[BCIntegrate_TEST] fix par at edge of allowed range

### DIFF
--- a/test/BCIntegrate_TEST.cxx
+++ b/test/BCIntegrate_TEST.cxx
@@ -162,6 +162,13 @@ public:
         m.SetRandomSeed(613);
         if (ndim >= 4)
             m.GetParameter(3).Fix(0.5);
+        // set to boundary of parameter range
+        // but the range should be small so the integral doesn't vanish
+        if (ndim == 5) {
+            BCParameter& p = m.GetParameter(4);
+            p.SetLimits(-15, 3);
+            p.Fix(3);
+        }
 
         /* optimization */
 
@@ -336,7 +343,7 @@ public:
         Integration();
         Optimization();
         FixedParameters(2);
-        FixedParameters(4);
+        FixedParameters(5);
         Slice();
     }
 } bcIntegrateTest;


### PR DESCRIPTION
Please add this test in addition to #199 to make sure things work in the future as well