### PR TITLE
[configure.ac] Add m4/ directory for libtool macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_HEADER_STDC
 AC_FUNC_UTIME_NULL
 
 # autoconf and libtool macros will be copied to m4/
-AC_CONFIG_MACRO_DIRS([m4])
+AC_CONFIG_MACRO_DIR([m4])
 
 dnl Get filename extension for dynamic libraries:
 SHLIBEXT="${shrext_cmds}"

--- a/configure.ac
+++ b/configure.ac
@@ -5,9 +5,12 @@ AC_INIT([BAT], 1.1.0-DEV, [], [BAT])
 AM_INIT_AUTOMAKE()
 AM_CONFIG_HEADER(config.h)
 AC_PROG_CXX
-AM_PROG_LIBTOOL
+LT_INIT
 AC_HEADER_STDC
 AC_FUNC_UTIME_NULL
+
+# autoconf and libtool macros will be copied to m4/
+AC_CONFIG_MACRO_DIRS([m4])
 
 dnl Get filename extension for dynamic libraries:
 SHLIBEXT="${shrext_cmds}"


### PR DESCRIPTION
Fixes error if autoconf and libtool are not installed in the default
location

configure.ac:8: warning: macro 'AM_PROG_LIBTOOL' not found in library
configure.ac:8: error: possibly undefined macro: AM_PROG_LIBTOOL
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.