### PR TITLE
[examples] Fix clang 3.8 undefined macro behavior

### DIFF
--- a/examples/advanced/advancedGraphFitter/graphFitterAdvancedExample.C
+++ b/examples/advanced/advancedGraphFitter/graphFitterAdvancedExample.C
@@ -29,9 +29,7 @@
 // Below are the includes needed for compilation of the macro.
 // The #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <BAT/BCAux.h>
 #include <BAT/BCLog.h>

--- a/examples/advanced/mtf/ensembleTest/ensembleTest.C
+++ b/examples/advanced/mtf/ensembleTest/ensembleTest.C
@@ -27,9 +27,7 @@
 // Below are the includes needed for compilation of the macro
 // the #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <BAT/BCAux.h>
 #include <BAT/BCGaussianPrior.h>

--- a/examples/advanced/mtf/mcstat/mcstat.C
+++ b/examples/advanced/mtf/mcstat/mcstat.C
@@ -27,9 +27,7 @@
 // Below are the includes needed for compilation of the macro
 // the #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <BAT/BCAux.h>
 #include <BAT/BCEngineMCMC.h>

--- a/examples/advanced/mtf/singleChannel/singleChannel.C
+++ b/examples/advanced/mtf/singleChannel/singleChannel.C
@@ -27,9 +27,7 @@
 // Below are the includes needed for compilation of the macro
 // the #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <BAT/BCAux.h>
 #include <BAT/BCGaussianPrior.h>

--- a/examples/advanced/mtf/twoChannels/twoChannels.C
+++ b/examples/advanced/mtf/twoChannels/twoChannels.C
@@ -27,9 +27,7 @@
 // Below are the includes needed for compilation of the macro
 // the #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <BAT/BCAux.h>
 #include <BAT/BCGaussianPrior.h>

--- a/examples/basic/efficiencyFitter/efficiencyFitterExample.C
+++ b/examples/basic/efficiencyFitter/efficiencyFitterExample.C
@@ -29,9 +29,7 @@
 // Below are the includes needed for compilation of the macro
 // the #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <TH1D.h>
 #include <TF1.h>

--- a/examples/basic/graphFitter/graphFitterSimpleExample.C
+++ b/examples/basic/graphFitter/graphFitterSimpleExample.C
@@ -29,9 +29,7 @@
 // Below are the includes needed for compilation of the macro
 // the #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <TGraphErrors.h>
 #include <TF1.h>

--- a/examples/basic/histogramFitter/histogramFitterExample.C
+++ b/examples/basic/histogramFitter/histogramFitterExample.C
@@ -28,9 +28,7 @@
 // Below are the includes needed for compilation of the macro
 // the #if ... #endif directives around the includes allow to
 // run the macro in both normal and compiled mode.
-#define COMPILER (!defined(__CINT__) && !defined(__CLING__))
-
-#if defined(__MAKECINT__) || defined(__ROOTCLING__) || COMPILER
+#if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
 #include <BAT/BCAux.h>
 #include <BAT/BCLog.h>


### PR DESCRIPTION
Motivated by #208, I updated the root macros to not rely on undefined behavior of macro expansion report by clang 3.8