### PR TITLE
[build] Fix broken linking of ROOT libs

### DIFF
--- a/models/base/Makefile.am
+++ b/models/base/Makefile.am
@@ -4,8 +4,8 @@ clean-local:
 	-rm -rf .includes
 
 lib_LTLIBRARIES= libBATmodels.la
-libBATmodels_la_LDFLAGS= -version-info 1:0:0
-libBATmodels_la_LIBADD = $(top_builddir)/src/libBAT.la
+libBATmodels_la_LDFLAGS= -version-info 1:0:0 $(ROOTLIBDIRFLAGS)
+libBATmodels_la_LIBADD = $(top_builddir)/src/libBAT.la $(ROOTLIBS)
 
 AM_CXXFLAGS = $(ROOTAUXCFLAGS) -Wall -fPIC -I.includes -I$(top_builddir)/src/.includes $(ROOTCFLAGS)
 AM_LDFLAGS  = -O

--- a/models/mtf/Makefile.am
+++ b/models/mtf/Makefile.am
@@ -4,8 +4,8 @@ clean-local:
 	-rm -rf .includes
 
 lib_LTLIBRARIES= libBATmtf.la
-libBATmtf_la_LDFLAGS= -version-info 1:0:0
-libBATmtf_la_LIBADD = $(top_builddir)/src/libBAT.la
+libBATmtf_la_LDFLAGS= -version-info 1:0:0 $(ROOTLIBDIRFLAGS)
+libBATmtf_la_LIBADD = $(top_builddir)/src/libBAT.la $(ROOTLIBS)
 
 AM_CXXFLAGS = $(ROOTAUXCFLAGS) -Wall -fPIC -I.includes -I$(top_builddir)/src/.includes $(ROOTCFLAGS)
 AM_LDFLAGS  = -O


### PR DESCRIPTION
#195 broke linking of ROOT libs (ROOStats in particular) on some
platforms (e.g. Ubuntu Linux).