### PR TITLE
[WIP] added RValues(Statistics, ...)

### DIFF
--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -1291,6 +1291,15 @@ public:
      * @return R value for set of batches of samples. */
     static double RValue(const std::vector<double>& means, const std::vector<double>& variances, unsigned n, bool correctForSamplingVariability = true);
 
+    
+    /**
+     * @see RValue(const std::vector<double>&,const std::vector<double>&,unsigned,bool);
+     * @param stats Vector of BCEngineMCMC::Statistics objects
+     * @param correctForSamplingVariability Flag to control correcting R value for initial sampling variability.
+     * @param n max number of variables to calculate RValues for (negative values indicate to calculate for all variables)
+     * @return R value for set of batches of samples. */
+    static std::vector<double> RValues(const std::vector<BCEngineMCMC::Statistics>& stats,  bool correctForSamplingVariability = true, int n = -1);
+    
     /**
      * Resets all containers used in MCMC and initializes starting points. */
     void MCMCInitialize();


### PR DESCRIPTION
Added a function to calculate RValues given a vector of BCEngineMCMC::Statistics objects. This is then used inside BCEngineMCMC and is useful for people who want to check the R values of their main run. I've also added the R values of the main run to the summary output.

Since we don't robustly check for convergence (in later subsamples), it may turn out that a pre-run that runs up to its limit without converging leads into a main run that has in fact converged. This will allow a user to see that his main run has converged, and save him from scrapping the results unnecessarily.