### PR TITLE
Hist fitter

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,18 +40,16 @@ recent version is needed, v1.15 is known to be sufficient.
 
 ### Required: ROOT
 
-ROOT is an object-oriented data-analysis framework. At
-http://root.cern.ch/, you can obtain the source code as well as binary
-distributions for a number of Linux distributions and Mac OS X
-versions. We advise to download the latest production release of
-ROOT. BAT is compatible with ROOT 6 and we regularly run unit tests
-with ROOT 5.34/36 to ensure backward compatibility.
+ROOT is an object-oriented data-analysis framework. At http://root.cern.ch/, you
+can obtain the source code as well as binary distributions for a number of Linux
+distributions and Mac OS X versions. We advise to download the latest production
+release of ROOT. BAT is compatible with ROOT >=5.34.19 and ROOT 6. We regularly
+run unit tests with ROOT 5 and ROOT 6 to ensure backward compatibility.
 
-On Linux, an alternative is to check your package manager for the
-availability of ROOT packages. Usually these packages are rather old
-but often they are good enough to build BAT. For example in Debian
-Jessie or Ubuntu 14.04, you can conveniently install the requirements
-with
+On Linux, an alternative is to check your package manager for the availability
+of ROOT packages. Usually these packages are rather old but often they are good
+enough to build BAT. For example on Ubuntu systems, you can conveniently install
+the requirements with
 
     sudo apt-get install libroot-graf2d-postscript-dev libroot-graf3d-g3d-dev libroot-math-foam-dev libroot-math-minuit-dev libroot-math-physics-dev libroot-math-mathmore-dev libroot-roofit-dev root-system-bin
 

--- a/configure.ac
+++ b/configure.ac
@@ -28,16 +28,16 @@ dnl
 dnl Check for debug mode
 dnl
 AC_ARG_ENABLE(
-	[debug],
-	[  --enable-debug          Compile in debug mode],
-	[
-		case "${enableval}" in
-			yes) debug=true ; echo Compiling in debug mode ;;
-			no)  debug=false ;;
-			*) AC_MSG_ERROR([bad value ${enableval} for --enable-debug]) ;;
-		esac
-	],
-	[debug=false]
+  [debug],
+  [  --enable-debug          Compile in debug mode],
+  [
+    case "${enableval}" in
+      yes) debug=true ; echo Compiling in debug mode ;;
+      no)  debug=false ;;
+      *) AC_MSG_ERROR([bad value ${enableval} for --enable-debug]) ;;
+    esac
+  ],
+  [debug=false]
 )
 AM_CONDITIONAL([DEBUG], [test x$debug = xtrue])
 
@@ -45,20 +45,20 @@ dnl
 dnl Check for parallel mode
 dnl
 AC_ARG_ENABLE(
-	[parallel],
-	[AS_HELP_STRING([--enable-parallel],[compile with OpenMP thread parallelization (default no)])],
-	[
-		case "${enableval}" in
-			yes) parallelization=1 ;
-				CXXFLAGS+=" -fopenmp" ;
-				LDFLAGS+=" -fopenmp" ;
-				DEP_CFLAGS="$DEP_CFLAGS -fopenmp" ;
-				DEP_LIBS="$DEP_LIBS -fopenmp" ;;
-			no)  parallelization=0 ;;
-			*) AC_MSG_ERROR([bad value ${enableval} for --enable-parallel]) ;;
-		esac
-	],
-	[parallelization=0]
+  [parallel],
+  [AS_HELP_STRING([--enable-parallel],[compile with OpenMP thread parallelization (default no)])],
+  [
+    case "${enableval}" in
+      yes) parallelization=1 ;
+        CXXFLAGS+=" -fopenmp" ;
+        LDFLAGS+=" -fopenmp" ;
+        DEP_CFLAGS="$DEP_CFLAGS -fopenmp" ;
+        DEP_LIBS="$DEP_LIBS -fopenmp" ;;
+      no)  parallelization=0 ;;
+      *) AC_MSG_ERROR([bad value ${enableval} for --enable-parallel]) ;;
+    esac
+  ],
+  [parallelization=0]
 )
 
 AC_DEFINE_UNQUOTED([THREAD_PARALLELIZATION], [$parallelization], [OpenMP thread parallelization])
@@ -70,11 +70,11 @@ dnl
 cuba_min_version=3.3
 AC_DEFINE_UNQUOTED([CUBA_MIN_VERSION], [$cuba_min_version], [Minimum cuba version])
 AC_ARG_WITH(
-	[cuba],
-	[AS_HELP_STRING([--with-cuba[[=DIR]]],[Compile with Cuba support (default: no). If a local build in 'cuba/' is found, it is used and Cuba is activated automatically. The optional DIR is the top of a Cuba installation. If DIR==download, a compatible version of cuba is downloaded from the official cuba website. If DIR is not given, the location is inferred from the 'partview' executable, else Cuba is assumed to be available in the system directories.])],
-	[
-		echo "compiling with Cuba support: requires version $cuba_min_version or later"
-	]
+  [cuba],
+  [AS_HELP_STRING([--with-cuba[[=DIR]]],[Compile with Cuba support (default: no). If a local build in 'cuba/' is found, it is used and Cuba is activated automatically. The optional DIR is the top of a Cuba installation. If DIR==download, a compatible version of cuba is downloaded from the official cuba website. If DIR is not given, the location is inferred from the 'partview' executable, else Cuba is assumed to be available in the system directories.])],
+  [
+    echo "compiling with Cuba support: requires version $cuba_min_version or later"
+  ]
 )
 
 AC_ARG_WITH(cuba_include_dir, AS_HELP_STRING([--with-cuba-include-dir=DIR    path to cuba.h file]))
@@ -85,51 +85,51 @@ AC_CHECK_PROGS(CURL, curl, false)
 AC_CHECK_PROGS(WGET, wget, false)
 
 if test "$with_cuba" = "yes"; then
-	use_cuba=yes
-	AC_PATH_PROG(cuba_bin_dir, [partview])
-	if test -f "$cuba_bin_dir" ; then
-		# up two levels: /usr/local/bin/partview -> /usr/local
-		with_cuba="$(dirname "$(dirname "$cuba_bin_dir")")"
-		AC_MSG_CHECKING([for cuba in $with_cuba])
-		AC_MSG_RESULT(yes)
-	fi
+  use_cuba=yes
+  AC_PATH_PROG(cuba_bin_dir, [partview])
+  if test -f "$cuba_bin_dir" ; then
+    # up two levels: /usr/local/bin/partview -> /usr/local
+    with_cuba="$(dirname "$(dirname "$cuba_bin_dir")")"
+    AC_MSG_CHECKING([for cuba in $with_cuba])
+    AC_MSG_RESULT(yes)
+  fi
 elif test "$with_cuba" = "no"; then
-	use_cuba=no
+  use_cuba=no
 elif test "$with_cuba" = "download"; then
-	use_cuba=yes
+  use_cuba=yes
 
-	cuba_version_default=4.2
-	local_cuba_dir="`pwd`/external/cuba-${cuba_version_default}"
-	cuba_url="http://www.feynarts.de/cuba/Cuba-${cuba_version_default}.tar.gz"
+  cuba_version_default=4.2
+  local_cuba_dir="`pwd`/external/cuba-${cuba_version_default}"
+  cuba_url="http://www.feynarts.de/cuba/Cuba-${cuba_version_default}.tar.gz"
 
-	with_cuba_include_dir="$local_cuba_dir"
-	with_cuba_lib_dir="$local_cuba_dir"
+  with_cuba_include_dir="$local_cuba_dir"
+  with_cuba_lib_dir="$local_cuba_dir"
 
-	if test ! -d "${local_cuba_dir}"; then
-		AC_MSG_NOTICE([Downloading and building in $local_cuba_dir])
+  if test ! -d "${local_cuba_dir}"; then
+    AC_MSG_NOTICE([Downloading and building in $local_cuba_dir])
 
-		if test "$CURL" != "false"; then
-			download_cmd="curl -L"
-		elif test "$WGET" != "false"; then
-			download_cmd="wget -O-"
-		else
-			AC_MSG_ERROR([Need either wget or curl to download Cuba.])
-		fi
+    if test "$CURL" != "false"; then
+      download_cmd="curl -L"
+    elif test "$WGET" != "false"; then
+      download_cmd="wget -O-"
+    else
+      AC_MSG_ERROR([Need either wget or curl to download Cuba.])
+    fi
 
-		mkdir -p "${local_cuba_dir}" \
-		&& (${download_cmd} "${cuba_url}" | tar --strip-components 1 -C "${local_cuba_dir}" --strip=1 -x -z) \
-		&& (
-			cd "${local_cuba_dir}" \
-			&& CFLAGS="-fPIC -O3 -fomit-frame-pointer -ffast-math -Wall" ./configure \
-			&& make lib
-		)
-	else
-		AC_MSG_NOTICE([Reusing existing local cuba build in $local_cuba_dir])
-	fi
+    mkdir -p "${local_cuba_dir}" \
+    && (${download_cmd} "${cuba_url}" | tar --strip-components 1 -C "${local_cuba_dir}" --strip=1 -x -z) \
+    && (
+      cd "${local_cuba_dir}" \
+      && CFLAGS="-fPIC -O3 -fomit-frame-pointer -ffast-math -Wall" ./configure \
+      && make lib
+    )
+  else
+    AC_MSG_NOTICE([Reusing existing local cuba build in $local_cuba_dir])
+  fi
 elif test -n "$with_cuba"; then
-	use_cuba=yes
+  use_cuba=yes
 else
-	use_cuba=no
+  use_cuba=no
 fi
 
 
@@ -140,150 +140,150 @@ LDFLAGS_BACKUP="$LDFLAGS"
 LIBS_BACKUP="$LIBS"
 
 if test "x$use_cuba" != xno; then
-	dnl check to see if lib and include can be determined automatically from $with_cuba
-	dnl if cuba just compiled, everything is in one directory
+  dnl check to see if lib and include can be determined automatically from $with_cuba
+  dnl if cuba just compiled, everything is in one directory
 
-	if test -z "$with_cuba_include_dir" ; then
-		if test -d "$with_cuba/include" ; then
-			with_cuba_include_dir="$with_cuba/include"
-		elif test -d $with_cuba ; then
-			with_cuba_include_dir="$with_cuba"
-		fi
-	fi
+  if test -z "$with_cuba_include_dir" ; then
+    if test -d "$with_cuba/include" ; then
+      with_cuba_include_dir="$with_cuba/include"
+    elif test -d $with_cuba ; then
+      with_cuba_include_dir="$with_cuba"
+    fi
+  fi
 
-	if test -z "$with_cuba_lib_dir" ; then
-		if test -d "$with_cuba/lib" ; then
-			with_cuba_lib_dir="$with_cuba/lib"
-		elif test -d $with_cuba ; then
-			with_cuba_lib_dir="$with_cuba"
-		fi
-	fi
+  if test -z "$with_cuba_lib_dir" ; then
+    if test -d "$with_cuba/lib" ; then
+      with_cuba_lib_dir="$with_cuba/lib"
+    elif test -d $with_cuba ; then
+      with_cuba_lib_dir="$with_cuba"
+    fi
+  fi
 
-	cubaincflags=""
-	if test -n "$with_cuba_include_dir"; then
-		echo "checking for cuba.h in $with_cuba_include_dir"
-		cubaincflags=-I$with_cuba_include_dir
-		CPPFLAGS+=" $cubaincflags"
-		CXXFLAGS+=" $cubaincflags"
-	else
-		echo "checking for cuba.h in system default directories"
-	fi
+  cubaincflags=""
+  if test -n "$with_cuba_include_dir"; then
+    echo "checking for cuba.h in $with_cuba_include_dir"
+    cubaincflags=-I$with_cuba_include_dir
+    CPPFLAGS+=" $cubaincflags"
+    CXXFLAGS+=" $cubaincflags"
+  else
+    echo "checking for cuba.h in system default directories"
+  fi
 
-	AC_CHECK_HEADERS(cuba.h, [], [AC_MSG_ERROR([Could not find cuba.h; use --with-cuba[[-include-dir]]=DIR or compile without cuba])])
+  AC_CHECK_HEADERS(cuba.h, [], [AC_MSG_ERROR([Could not find cuba.h; use --with-cuba[[-include-dir]]=DIR or compile without cuba])])
 
-	cubaldflags=""
-	if test -n "$with_cuba_lib_dir"; then
-	echo "checking for cuba library in path $with_cuba_lib_dir"
-	cubaldflags="-L$with_cuba_lib_dir -lcuba"
-	LDFLAGS+=" $cubaldflags"
-	else
-	echo "checking for cuba library in system default directories"
-	fi
+  cubaldflags=""
+  if test -n "$with_cuba_lib_dir"; then
+  echo "checking for cuba library in path $with_cuba_lib_dir"
+  cubaldflags="-L$with_cuba_lib_dir -lcuba"
+  LDFLAGS+=" $cubaldflags"
+  else
+  echo "checking for cuba library in system default directories"
+  fi
 
-	dnl Check for the right CUBA interface
-	AC_COMPILE_IFELSE([
-	AC_LANG_SOURCE(
-	[[
-	#include <cuba.h>
-	int integrand(const int * ndim, const double xx[], const int * ncomp, double ff[], void * userdata){return 0;}
+  dnl Check for the right CUBA interface
+  AC_COMPILE_IFELSE([
+  AC_LANG_SOURCE(
+  [[
+  #include <cuba.h>
+  int integrand(const int * ndim, const double xx[], const int * ncomp, double ff[], void * userdata){return 0;}
 
-	int main()
-	{
-		int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew;
-		double epsrel, epsabs, flatness;
-		int * nregions, *fail, *neval;
-		double * integral, *error, *prob;
-		const char * statefile = "";
-		void * userdata;
-		Suave(ndim, ncomp, &integrand, userdata, nvec,
-				epsrel, ebsabs, flags, seed, mineval, maxeval,
-				nnew, flatness, statefile,
-				nregions, neval, fail, integral, error, prob);
+  int main()
+  {
+    int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew;
+    double epsrel, epsabs, flatness;
+    int * nregions, *fail, *neval;
+    double * integral, *error, *prob;
+    const char * statefile = "";
+    void * userdata;
+    Suave(ndim, ncomp, &integrand, userdata, nvec,
+        epsrel, ebsabs, flags, seed, mineval, maxeval,
+        nnew, flatness, statefile,
+        nregions, neval, fail, integral, error, prob);
 
-		return 0;
-	}
-	]]
-	)],
-	[cuba_version=3.3
-	AC_DEFINE([CUBAVERSION], [33], [cuba interface version 3.3 detected])],
-	[])
+    return 0;
+  }
+  ]]
+  )],
+  [cuba_version=3.3
+  AC_DEFINE([CUBAVERSION], [33], [cuba interface version 3.3 detected])],
+  [])
 
-	if test x$cuba_version = x; then
-	AC_COMPILE_IFELSE([
-	AC_LANG_SOURCE(
-	[[
-	#include <cuba.h>
-	int integrand(const int * ndim, const double xx[], const int * ncomp, double ff[], void * userdata){return 0;}
+  if test x$cuba_version = x; then
+  AC_COMPILE_IFELSE([
+  AC_LANG_SOURCE(
+  [[
+  #include <cuba.h>
+  int integrand(const int * ndim, const double xx[], const int * ncomp, double ff[], void * userdata){return 0;}
 
-	int main()
-	{
-		int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, spin;
-		double epsrel, epsabs, flatness;
-		int * nregions, *fail, *neval;
-		double * integral, *error, *prob;
-		const char * statefile = "";
-		void * userdata;
-		Suave(ndim, ncomp, &integrand, userdata, nvec,
-				epsrel, ebsabs, flags, seed, mineval, maxeval,
-				nnew, flatness, statefile,
-				spin, /*spin was added in 4.0 */
-				nregions, neval, fail, integral, error, prob);
+  int main()
+  {
+    int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, spin;
+    double epsrel, epsabs, flatness;
+    int * nregions, *fail, *neval;
+    double * integral, *error, *prob;
+    const char * statefile = "";
+    void * userdata;
+    Suave(ndim, ncomp, &integrand, userdata, nvec,
+        epsrel, ebsabs, flags, seed, mineval, maxeval,
+        nnew, flatness, statefile,
+        spin, /*spin was added in 4.0 */
+        nregions, neval, fail, integral, error, prob);
 
-		return 0;
-	}
-	]]
-	)],
-	[cuba_version=4.0
-	AC_DEFINE([CUBAVERSION], [40], [cuba interface version 4.0 detected])],
-	[])
-	fi
+    return 0;
+  }
+  ]]
+  )],
+  [cuba_version=4.0
+  AC_DEFINE([CUBAVERSION], [40], [cuba interface version 4.0 detected])],
+  [])
+  fi
 
-	if test x$cuba_version = x; then
-	AC_COMPILE_IFELSE([
-	AC_LANG_SOURCE(
-	[[
-	#include <cuba.h>
-	int integrand(const int * ndim, const double xx[], const int * ncomp, double ff[], void * userdata){return 0;}
+  if test x$cuba_version = x; then
+  AC_COMPILE_IFELSE([
+  AC_LANG_SOURCE(
+  [[
+  #include <cuba.h>
+  int integrand(const int * ndim, const double xx[], const int * ncomp, double ff[], void * userdata){return 0;}
 
-	int main()
-	{
-		int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, nmin, spin;
-		double epsrel, epsabs, flatness;
-		int * nregions, *fail, *neval;
-		double * integral, *error, *prob;
-		const char * statefile = "";
-		void * userdata;
-		Suave(ndim, ncomp, &integrand, userdata, nvec,
-				epsrel, epsabs, flags, seed, mineval, maxeval, nnew,
-				nmin, /* nmin added in 4.1 */
-				flatness, statefile, spin,
-				nregions, neval, fail, integral, error, prob);
+  int main()
+  {
+    int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, nmin, spin;
+    double epsrel, epsabs, flatness;
+    int * nregions, *fail, *neval;
+    double * integral, *error, *prob;
+    const char * statefile = "";
+    void * userdata;
+    Suave(ndim, ncomp, &integrand, userdata, nvec,
+        epsrel, epsabs, flags, seed, mineval, maxeval, nnew,
+        nmin, /* nmin added in 4.1 */
+        flatness, statefile, spin,
+        nregions, neval, fail, integral, error, prob);
 
-		return 0;
-	}
-	]]
-	)],
-	[cuba_version=4.1
-	AC_DEFINE([CUBAVERSION], [41], [cuba interface version 4.1 detected])],
-	[])
-	fi
+    return 0;
+  }
+  ]]
+  )],
+  [cuba_version=4.1
+  AC_DEFINE([CUBAVERSION], [41], [cuba interface version 4.1 detected])],
+  [])
+  fi
 
-	if test x$cuba_version = x; then
-		AC_MSG_ERROR([This version of cuba does not match
-		the interface of the supported version $cuba_min_version or later])
-	else
-		echo detected cuba matching the interface of version $cuba_version
-	fi
+  if test x$cuba_version = x; then
+    AC_MSG_ERROR([This version of cuba does not match
+    the interface of the supported version $cuba_min_version or later])
+  else
+    echo detected cuba matching the interface of version $cuba_version
+  fi
 
-	AC_CHECK_LIB(cuba,main,[],[AC_MSG_ERROR([Could not find libcuba.a; use --with-cuba-lib-dir=DIR or compile without cuba])])
-	AC_SUBST(CUBAINCLUDE,[$cubaincflags])
-	AC_SUBST(CUBALIB,[$cubaldflags])
+  AC_CHECK_LIB(cuba,main,[],[AC_MSG_ERROR([Could not find libcuba.a; use --with-cuba-lib-dir=DIR or compile without cuba])])
+  AC_SUBST(CUBAINCLUDE,[$cubaincflags])
+  AC_SUBST(CUBALIB,[$cubaldflags])
 
-	dnl passed all tests, so build with cuba
-	AM_CONDITIONAL([CUBA], [test 1 -eq 1])
+  dnl passed all tests, so build with cuba
+  AM_CONDITIONAL([CUBA], [test 1 -eq 1])
 else
-	echo compiling without cuba
-	AM_CONDITIONAL([CUBA], [test 1 -eq 0])
+  echo compiling without cuba
+  AM_CONDITIONAL([CUBA], [test 1 -eq 0])
 fi
 
 dnl Restore compiler/linker flags (without cuba additions):
@@ -298,32 +298,32 @@ dnl
 dnl Check for ROOT
 dnl
 AC_DEFUN(
-	[REQUIRE_ROOT_VERSION],
-	[require_ROOT_version=$1]
+  [REQUIRE_ROOT_VERSION],
+  [require_ROOT_version=$1]
 )
-REQUIRE_ROOT_VERSION([5.34.14])
+REQUIRE_ROOT_VERSION([5.34.19])
 
 dnl RooStats
 AC_ARG_ENABLE(
-	[roostats],
-	[AS_HELP_STRING([--enable-roostats],[compile with RooStats support (default: no)])],
-	[
-		use_roostats=${enableval};
-	],
-	[use_roostats=no]
+  [roostats],
+  [AS_HELP_STRING([--enable-roostats],[compile with RooStats support (default: no)])],
+  [
+    use_roostats=${enableval};
+  ],
+  [use_roostats=no]
 )
 
 dnl ROOT
 m4_include(tools/build/root.m4)
 ROOT_PATH(
-	$require_ROOT_version,
-	,
-	[
-		AC_MSG_ERROR([ROOT cannot be found. Please ensure that it is installed
-			and that either \$ROOTSYS is defined corectly or root-config is in the path.
-			One can pass --with-rootsys=/path/to/rootsys to configure as well.])
-		exit
-	]
+  $require_ROOT_version,
+  ,
+  [
+    AC_MSG_ERROR([ROOT cannot be found. Please ensure that it is installed
+      and that either \$ROOTSYS is defined corectly or root-config is in the path.
+      One can pass --with-rootsys=/path/to/rootsys to configure as well.])
+    exit
+  ]
 )
 dnl add some libraries to set of basic root libraries
 ROOTLIBS="$ROOTLIBS -lMinuit"
@@ -336,26 +336,26 @@ AC_MSG_CHECKING(whether ROOT is compiled with MathMore support)
 hasmathmore=`$ROOTCONF --has-mathmore`
 AC_MSG_RESULT($hasmathmore)
 if test x$hasmathmore = xyes; then
-	 ROOTLIBS="$ROOTLIBS -lMathMore"
-	 AC_DEFINE([ROOTMATHMORE], 1,  [ROOT MathMore available])
+   ROOTLIBS="$ROOTLIBS -lMathMore"
+   AC_DEFINE([ROOTMATHMORE], 1,  [ROOT MathMore available])
 fi
 AM_CONDITIONAL([ROOTMATHMORE], [test x$hasmathmore = xyes])
 
 dnl RooFit
 if test x$use_roostats = xyes; then
-	HAS_ROOSTATS(
-		AC_MSG_RESULT([Compiling BAT with RooStats support.]),
-		[
-			AC_MSG_RESULT([ROOT was compiled without RooFit support.])
-			AC_MSG_RESULT([To add RooStats support, recompile ROOT or provide path to different version.])
-			AC_MSG_RESULT([Compiling BAT without RooStats support.])
-			use_roostats=no
-		]
-	)
+  HAS_ROOSTATS(
+    AC_MSG_RESULT([Compiling BAT with RooStats support.]),
+    [
+      AC_MSG_RESULT([ROOT was compiled without RooFit support.])
+      AC_MSG_RESULT([To add RooStats support, recompile ROOT or provide path to different version.])
+      AC_MSG_RESULT([Compiling BAT without RooStats support.])
+      use_roostats=no
+    ]
+  )
 fi
 AM_CONDITIONAL([ROOSTATS], [test x$use_roostats = xyes])
 if test x$use_roostats = xyes; then
-	ROOTLIBS="$ROOTLIBS -lRooFitCore -lRooFit -lRooStats -lFoam"
+  ROOTLIBS="$ROOTLIBS -lRooFitCore -lRooFit -lRooStats -lFoam"
 fi
 
 
@@ -363,11 +363,11 @@ USE_RPATH="no"
 ROOTLIBDIRFLAGS="-L$ROOTLIBDIR"
 PKG_LIBS="-lBAT -lBATmodels -lBATmtf"
 case "${host_os}" in
-	darwin*)
-		USE_RPATH="yes"
-	ROOTLIBDIRFLAGS="-Wl,-rpath,$ROOTLIBDIR ${ROOTLIBDIRFLAGS}"
-	PKG_LIBS="-Wl,-rpath,\${libdir} ${PKG_LIBS}"
-	;;
+  darwin*)
+    USE_RPATH="yes"
+  ROOTLIBDIRFLAGS="-Wl,-rpath,$ROOTLIBDIR ${ROOTLIBDIRFLAGS}"
+  PKG_LIBS="-Wl,-rpath,\${libdir} ${PKG_LIBS}"
+  ;;
 esac
 AM_CONDITIONAL([COND_USE_RPATH], [test "$USE_RPATH" = "yes"])
 AC_SUBST(ROOTLIBDIRFLAGS)
@@ -384,7 +384,7 @@ AM_CONDITIONAL([COND_PKGCONFIG], [test "$PKGCONFIG" != "false"])
 
 dnl files that may not be part of the release but exist only in a checkout of the source repository
 if test -f "$srcdir/doc/introduction/versions.tex.in" ; then
-		AC_OUTPUT(doc/introduction/versions.tex)
+    AC_OUTPUT(doc/introduction/versions.tex)
 fi
 
 dnl directories needed to store output files (e.g. from unit tests) in the proper place
@@ -393,36 +393,36 @@ AC_DEFINE_UNQUOTED([BAT_SRCDIR], "`readlink -f $ac_pwd/$srcdir`", [Absolute path
 AC_DEFINE_UNQUOTED([BAT_TESTDIR], "$ac_pwd/test/", [Absolute path to the test directory])
 
 AC_OUTPUT(
-	Makefile
-	bat.pc
-	bat-config
-	test-env.sh
-	src/Makefile
-	models/base/Makefile
-	models/mtf/Makefile
-	test/Makefile
-	tools/MakefileTemplate
-	examples/Makefile
-	examples/basic/Makefile
-	examples/basic/binomial/Makefile
-	examples/basic/combination1d/Makefile
-	examples/basic/combination2d/Makefile
-	examples/basic/efficiencyFitter/Makefile
-	examples/basic/errorPropagation/Makefile
-	examples/basic/graphFitter/Makefile
-	examples/basic/histogramFitter/Makefile
-	examples/basic/poisson/Makefile
-	examples/basic/rootOutput/Makefile
-	examples/advanced/Makefile
-	examples/advanced/advancedGraphFitter/Makefile
-	examples/advanced/mtf/Makefile
-	examples/advanced/mtf/ensembleTest/Makefile
-	examples/advanced/mtf/mcstat/Makefile
-	examples/advanced/mtf/singleChannel/Makefile
-	examples/advanced/mtf/systematics/Makefile
-	examples/advanced/mtf/twoChannels/Makefile
-	examples/advanced/polynomialFit/Makefile
-	examples/advanced/referenceCounting/Makefile
-	examples/advanced/rooInterface/Makefile
-	examples/advanced/trialFunction/Makefile
+  Makefile
+  bat.pc
+  bat-config
+  test-env.sh
+  src/Makefile
+  models/base/Makefile
+  models/mtf/Makefile
+  test/Makefile
+  tools/MakefileTemplate
+  examples/Makefile
+  examples/basic/Makefile
+  examples/basic/binomial/Makefile
+  examples/basic/combination1d/Makefile
+  examples/basic/combination2d/Makefile
+  examples/basic/efficiencyFitter/Makefile
+  examples/basic/errorPropagation/Makefile
+  examples/basic/graphFitter/Makefile
+  examples/basic/histogramFitter/Makefile
+  examples/basic/poisson/Makefile
+  examples/basic/rootOutput/Makefile
+  examples/advanced/Makefile
+  examples/advanced/advancedGraphFitter/Makefile
+  examples/advanced/mtf/Makefile
+  examples/advanced/mtf/ensembleTest/Makefile
+  examples/advanced/mtf/mcstat/Makefile
+  examples/advanced/mtf/singleChannel/Makefile
+  examples/advanced/mtf/systematics/Makefile
+  examples/advanced/mtf/twoChannels/Makefile
+  examples/advanced/polynomialFit/Makefile
+  examples/advanced/referenceCounting/Makefile
+  examples/advanced/rooInterface/Makefile
+  examples/advanced/trialFunction/Makefile
 )

--- a/models/base/BCEfficiencyFitter.cxx
+++ b/models/base/BCEfficiencyFitter.cxx
@@ -50,16 +50,9 @@ BCEfficiencyFitter::BCEfficiencyFitter(const TH1& trials, const TH1& successes, 
         }
     }
 
-    // After checking, we can copy.
-    // Unfortunately the Copy() method is not public in very old versions of ROOT.
-    // But the workaround is good enough for our purposes.
-#if ROOTVERSION >= 5034019
     trials.Copy(fTrials);
     successes.Copy(fSuccesses);
-#else
-    BCFitter::CopyHist(trials, fTrials);
-    BCFitter::CopyHist(successes, fSuccesses);
-#endif
+
     // create data points and add them to the data set.
     for (int i = 0; i < fTrials.GetNbinsX(); ++i)
         fFitterDataSet.AddDataPoint(BCDataPoint(2));

--- a/models/base/BCFitter.cxx
+++ b/models/base/BCFitter.cxx
@@ -198,12 +198,6 @@ double BCFitter::Integral(const std::vector<double>& params, const double xmin, 
 {
     TF1& f = GetFitFunction();
 
-    // set the parameters of the function
-    // passing the pointer to first element of the vector is
-    // not completely safe as there might be an implementation where
-    // the vector elements are not stored consecutively in memory.
-    // however it is much faster than copying the contents, especially
-    // for large number of parameters
     f.SetParameters(&params[0]);
 
     // use ROOT's TH1::Integral method
@@ -267,8 +261,10 @@ TGraph* BCFitter::GetErrorBandGraph(double level1, double level2) const
     std::vector<double> ymax = GetErrorBand(level2);
 
     for (int i = 0; i < nx; i++) {
-        graph->SetPoint(i, fErrorBandXY.GetXaxis()->GetBinCenter(i + 1), ymin[i]);
-        graph->SetPoint(nx + i, fErrorBandXY.GetXaxis()->GetBinCenter(nx - i), ymax[nx - i - 1]);
+        graph->SetPoint(i, fErrorBandXY.GetXaxis()->GetBinCenter(i + 1),
+                        ymin[i] * GraphCorrection(i + 1));
+        graph->SetPoint(nx + i, fErrorBandXY.GetXaxis()->GetBinCenter(nx - i),
+                        ymax[nx - i - 1] * GraphCorrection(i + 1));
     }
 
     return graph;
@@ -304,7 +300,7 @@ TH2* BCFitter::GetGraphicalErrorBandXY(double level, int nsmooth, bool overcover
 TGraph* BCFitter::GetFitFunctionGraph(const std::vector<double>& parameters)
 {
     // define new graph
-    int nx = fErrorBandXY.GetNbinsX();
+    const int nx = fErrorBandXY.GetNbinsX();
     TGraph* graph = new TGraph(nx);
 
     // loop over x values
@@ -313,7 +309,7 @@ TGraph* BCFitter::GetFitFunctionGraph(const std::vector<double>& parameters)
 
         std::vector<double> xvec;
         xvec.push_back(x);
-        double y = FitFunction(xvec, parameters);
+        double y = FitFunction(xvec, parameters) * GraphCorrection(i + 1);
         xvec.clear();
 
         graph->SetPoint(i, x, y);
@@ -335,7 +331,7 @@ TGraph* BCFitter::GetFitFunctionGraph(const std::vector<double>& parameters, dou
         double x = (double) i * dx + xmin;
         std::vector<double> xvec;
         xvec.push_back(x);
-        double y = FitFunction(xvec, parameters);
+        double y = FitFunction(xvec, parameters) * GraphCorrection(i + 1);
 
         xvec.clear();
 

--- a/models/base/BCFitter.cxx
+++ b/models/base/BCFitter.cxx
@@ -368,19 +368,3 @@ void BCFitter::SetErrorBandContinuous(bool flag)
     // copy data x-values
     fErrorBandX = fDataSet->GetDataComponents(fFitFunctionIndexX);
 }
-
-// ---------------------------------------------------------
-void BCFitter::CopyHist(const TH1& source, TH1D& dest)
-{
-    std::vector<double> bins(source.GetNbinsX() + 1);
-    source.GetXaxis()->GetLowEdge(&bins[0]);
-    // now add the overflow left edge
-    bins.back() = source.GetXaxis()->GetXmax();
-    dest = TH1D(source.GetName(),
-                Form("%s;%s;%s", source.GetTitle(), source.GetXaxis()->GetTitle(), source.GetYaxis()->GetTitle()),
-                source.GetNbinsX(), &bins[0]);
-    // copy contents (include underflow and overflow)
-    for (int i = 0; i <= source.GetNbinsX() + 1; ++i) {
-        dest.SetBinContent(i, source.GetBinContent(i));
-    }
-}

--- a/models/base/BCFitter.h
+++ b/models/base/BCFitter.h
@@ -246,13 +246,6 @@ private:
 
 protected:
     /**
-     * Copy over the most important properties of a 1D histogram.
-     * This function is to emulate the TH1::Copy() method for our purposes.
-     * It is not needed for root 5.34.19 and higher.
-     */
-    static void CopyHist(const TH1& source, TH1D& destination);
-
-    /**
      * Flag whether or not to fill the error band */
     bool fFlagFillErrorBand;
 

--- a/models/base/BCFitter.h
+++ b/models/base/BCFitter.h
@@ -305,6 +305,12 @@ protected:
      * as it is used internally. */
     using BCModel::SetDataSet;
     using BCModel::GetDataSet;
+
+    /** Take care of bin width when creating a graph from the fit function */
+    virtual double GraphCorrection(unsigned /* ibin */) const
+    {
+        return 1.0;
+    }
 };
 
 // ---------------------------------------------------------

--- a/models/base/BCHistogramFitter.cxx
+++ b/models/base/BCHistogramFitter.cxx
@@ -63,19 +63,13 @@ BCHistogramFitter::BCHistogramFitter(const TH1& hist, const TF1& func, const std
 }
 
 // ---------------------------------------------------------
-BCHistogramFitter::~BCHistogramFitter() {}
-
-// ---------------------------------------------------------
 double BCHistogramFitter::LogLikelihood(const std::vector<double>& params)
 {
     // initialize probability
     double loglikelihood = 0;
 
-    // get the number of bins
-    int nbins = fHistogram.GetNbinsX();
-
     // loop over all bins
-    for (int ibin = 1; ibin <= nbins; ++ibin) {
+    for (int ibin = 1; ibin <= fHistogram.GetNbinsX(); ++ibin) {
         // get bin edges and integrate for expectation
         const double xmin = fHistogram.GetXaxis()->GetBinLowEdge(ibin);
         const double xmax = fHistogram.GetXaxis()->GetBinUpEdge(ibin);
@@ -249,4 +243,10 @@ bool BCHistogramFitter::CalculatePValueLeastSquares(const std::vector<double>& p
 
     // no error
     return true;
+}
+
+// ---------------------------------------------------------
+double BCHistogramFitter::GraphCorrection(unsigned ibin) const
+{
+    return fHistogram.GetXaxis()->GetBinUpEdge(ibin) - fHistogram.GetXaxis()->GetBinLowEdge(ibin);
 }

--- a/models/base/BCHistogramFitter.cxx
+++ b/models/base/BCHistogramFitter.cxx
@@ -34,13 +34,7 @@ BCHistogramFitter::BCHistogramFitter(const TH1& hist, const TF1& func, const std
     if (hist.GetDimension() != 1)
         throw std::invalid_argument("Only 1D histograms supported");
 
-    // Unfortunately the Copy() method is not public in very old versions of ROOT.
-    // But the workaround is good enough for our purposes.
-#if ROOTVERSION >= 5034019
     hist.Copy(fHistogram);
-#else
-    BCFitter::CopyHist(hist, fHistogram);
-#endif
 
     // create data points and add them to the data set.
     // the x value is the lower edge of the bin, and

--- a/models/base/BCHistogramFitter.h
+++ b/models/base/BCHistogramFitter.h
@@ -47,7 +47,7 @@ public:
 
     /**
      * The default destructor. */
-    virtual ~BCHistogramFitter();
+    virtual ~BCHistogramFitter() {};
 
     /* @} */
 
@@ -122,6 +122,8 @@ protected:
     /**
      * fPValue accounting for degrees of freedom. */
     double fPValueNDoF;
+
+    virtual double GraphCorrection(unsigned ibin) const;
 };
 
 // ---------------------------------------------------------

--- a/tools/test-bat.sh
+++ b/tools/test-bat.sh
@@ -4,6 +4,6 @@
 
 ./autogen.sh
 ./configure --with-cuba=download --enable-roostats --enable-parallel
-make -j`nprocs` distcheck
+make -j`nprocs` distcheck VERBOSE=1
 
 echo "OK"


### PR DESCRIPTION
This PR 

* bumps the minimum root version to 5.34.19 (so the `TH1::Copy` function is available)
* convert the mixture of tabs and spaces in `configure.ac` to spaces
* fixes #143 by taking into account the bin volume when drawing a graph
* modifies the histFitter example to allow changing values more easily following the DRY principle