### PR TITLE
Fixed drawing in BCEfficiencyFitter

### DIFF
--- a/examples/basic/efficiencyFitter/efficiencyFitterExample.C
+++ b/examples/basic/efficiencyFitter/efficiencyFitterExample.C
@@ -35,7 +35,6 @@
 #include <TF1.h>
 #include <TCanvas.h>
 #include <TRandom3.h>
-#include <TMath.h>
 
 #include <BAT/BCAux.h>
 #include <BAT/BCLog.h>
@@ -54,7 +53,7 @@ void efficiencyFitterExample()
 
     // -------------------------
     // define the fit function, which is also used in the generation of the data
-    TF1 f1("f1", "0.5*(1 + TMath::Erf((x-[0])/[1]))", 0.0, 100.0);
+    TF1 f1("f1", "0.5 * (1 + TMath::Erf((x - [0]) / [1]))", 0.0, 100.0);
     f1.SetParLimits(0, 35.0, 45.0);
     f1.SetParLimits(1, 10.0, 20.0);
     f1.SetParNames("mean", "sigma");
@@ -62,44 +61,38 @@ void efficiencyFitterExample()
 
     // -------------------------
     // Create new histograms:
-    TH1D h_denom("h_denom", ";x;N", 100, 0.0, 100.0);
-    h_denom.SetStats(kFALSE);
-
+    TH1D h_trials("h_trials", "Trials;x;N", 100, 0.0, 100.0);
+    h_trials.SetStats(false);
+    
     // cloning ensures identical binning
-    TH1D h_numer(h_denom);
-    h_numer.SetName("h_numer");
-
-    // set drawing options
-    h_denom.SetLineColor(kBlack);
-    h_denom.SetFillColor(5);
-    h_denom.SetFillStyle(1001);
-
-    h_numer.SetLineColor(kRed);
-    h_numer.SetLineWidth(2);
+    TH1D h_successes(h_trials);
+    h_successes.SetName("h_successes");
+    h_successes.SetTitle("Successes");
     // -------------------------
 
     // -------------------------
     // Fill histograms with data:
     // initialize random number generator with seed = 1234
-    gRandom = new TRandom3(1234);
+    TRandom3 R(1234);
 
-    // Fill h_denom randomly from Landau distribution
+    // Fill h_trials randomly from Landau distribution
     // with mean = 30 and sigma = 8; simulate 1000 events
     for (unsigned i = 0; i < 1000 ; ++i)
-        h_denom.Fill( gRandom->Landau(30., 8.) );
+        h_trials.Fill(R.Landau(30., 8.));
 
-    // Fill h_numer, with probability of accenting entry from h_denom
-    // following an error function with a smearing according to the
-    // binomial distribution with parameters (mean, sigma) := (40, 15)
-    f1.SetParameters(40, 15);
-    for (int b = 1; b <= h_numer.GetNbinsX(); ++b) {
-        double eff = f1.Integral(h_numer.GetXaxis()->GetBinLowEdge(b), h_numer.GetXaxis()->GetBinUpEdge(b)) / h_numer.GetXaxis()->GetBinWidth(b);
-        h_numer.SetBinContent(b, gRandom->Binomial(int(h_denom.GetBinContent(b)), eff));
+    // Fill h_successes, with probability of accepting the trials from
+    // h_trials following the error function defined above with a
+    // smearing according to the binomial distribution with parameters
+    // (mean, sigma) := (40, 15)
+    f1.SetParameters(40., 15.);
+    for (int i = 1; i <= h_successes.GetNbinsX(); ++i) {
+        double eff = f1.Integral(h_successes.GetXaxis()->GetBinLowEdge(i), h_successes.GetXaxis()->GetBinUpEdge(i)) / h_successes.GetXaxis()->GetBinWidth(i);
+        h_successes.SetBinContent(i, R.Binomial(static_cast<int>(h_trials.GetBinContent(i)), eff));
     }
     // -------------------------
 
     // create a new efficiency fitter
-    BCEfficiencyFitter hef(h_denom, h_numer, f1);
+    BCEfficiencyFitter hef(h_trials, h_successes, f1);
     hef.SetRandomSeed(1346);
 
     // set options for evaluating the fit function
@@ -111,7 +104,7 @@ void efficiencyFitterExample()
     // set options for MCMC
     hef.SetPrecision(BCEngineMCMC::kQuick);
 
-    // // perform fit
+    // perform fit
     hef.Fit();
 
     // print data and fit
@@ -119,11 +112,9 @@ void efficiencyFitterExample()
     c.Divide(2, 1);
 
     c.cd(1);
-    h_denom.Draw();
-    h_numer.Draw("same");
-
+    hef.DrawData(true);
+    
     c.cd(2);
-
     hef.DrawFit("", true); // draw with a legend
 
     // print to file

--- a/examples/basic/efficiencyFitter/efficiencyFitterExample.C
+++ b/examples/basic/efficiencyFitter/efficiencyFitterExample.C
@@ -77,7 +77,7 @@ void efficiencyFitterExample()
 
     // Fill h_trials randomly from Landau distribution
     // with mean = 30 and sigma = 8; simulate 1000 events
-    for (unsigned i = 0; i < 1000 ; ++i)
+    for (int i = 0; i < 1000 ; ++i)
         h_trials.Fill(R.Landau(30., 8.));
 
     // Fill h_successes, with probability of accepting the trials from

--- a/models/base/BCEfficiencyFitter.h
+++ b/models/base/BCEfficiencyFitter.h
@@ -139,6 +139,10 @@ public:
     virtual void Fit();
 
     /**
+     * Draw the data in the current pad. */
+    virtual void DrawData(bool flaglegend = false);
+    
+    /**
      * Draw the fit in the current pad. */
     virtual void DrawFit(const std::string& options = "", bool flaglegend = false);
 

--- a/models/base/BCFitter.cxx
+++ b/models/base/BCFitter.cxx
@@ -255,6 +255,7 @@ TGraph* BCFitter::GetErrorBandGraph(double level1, double level2) const
     TGraph* graph = new TGraph(2 * nx);
     graph->SetFillStyle(1001);
     graph->SetFillColor(kYellow);
+    graph->SetLineWidth(0);
 
     // get error bands
     std::vector<double> ymin = GetErrorBand(level1);


### PR DESCRIPTION
Fixes issue #233 .

However, I have a segfault when I run the example `efficiencyFitterExample.C` that stems from the final command `hef.PrintAllMarginalized("distributions.pdf")`.

@fredRos, can you please check if you get this same segfault (also with my updated code in this PR)?