### PR TITLE
Fix thread-safety issues

### DIFF
--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -93,6 +93,99 @@ public:
     /** \name Structs */
     /** @{ */
 
+private:
+    // grant friendship to BCModel to access the ThreadLocalStorage
+    friend class BCModel;
+    
+    /**
+     * Keeps variables that need to be both members and thread local.
+     */
+    struct ThreadLocalStorage {
+        /**
+         * Store local proposal point  */
+        std::vector<double> parameters;
+
+        /**
+         * Store log_prior of local proposal point */
+        double log_prior;
+
+        /**
+         * Store log_likelihood of local proposal point */
+        double log_likelihood;
+
+        /**
+         * Store log_probability of local proposal point */
+        double log_probability;
+
+        /**
+         * Random number generator */
+        TRandom3* rng;
+
+        /**
+         * Temp vector for matrix multiplication in multivariate proposal */
+        TVectorD yLocal;
+
+        /**
+         * Constructor
+         * @param dim Dimension of a temporary parameter vector
+         */
+        ThreadLocalStorage(unsigned dim);
+
+        /**
+         * Copy constructor. */
+        ThreadLocalStorage(const ThreadLocalStorage& other);
+
+        /**
+         * Assignment operator */
+        ThreadLocalStorage& operator = (ThreadLocalStorage other);
+
+        /** swap, can't be a friend this time because this struct is private */
+        void swap(BCEngineMCMC::ThreadLocalStorage& A, BCEngineMCMC::ThreadLocalStorage& B);
+
+        /**
+         * Destructor */
+        virtual ~ThreadLocalStorage();
+
+        /**
+         * Scale a Gaussian random variate such that it becomes a student's t variate;
+         * i.e. return `sqrt(dof / chi2)`, where `chi2` is a variate from a chi2 distribution
+         * with `dof` degrees of freedom.
+         *
+         * If `dof <= 0`, simply return 1 to keep the Gaussian distribution.
+         */
+        double scale(double dof);
+    };
+
+public:
+
+    /** A struct for holding a state in a Markov chain. */
+    struct ChainState {
+        unsigned iteration;     ///< iteration number
+        std::vector<double> parameters; ///< parameter point
+        std::vector<double> observables; ///< observables at parameter point 
+        double log_probability; ///< log(probability)
+        double log_likelihood;  ///< log(likelihood)
+        double log_prior;       ///< log(prior)
+
+        /** Constructor */
+        ChainState(int n_obs = 0) : iteration(0),
+                                    observables(std::vector<double>(n_obs, 0.)),
+                                    log_probability(-std::numeric_limits<double>::infinity()),
+                                    log_likelihood(-std::numeric_limits<double>::infinity()),
+                                    log_prior(-std::numeric_limits<double>::infinity())
+            {}
+
+        /** assignment */
+        ChainState& operator=(const ThreadLocalStorage& tls)
+            {
+                parameters = tls.parameters;
+                log_prior = tls.log_prior;
+                log_likelihood = tls.log_likelihood;
+                log_probability = tls.log_probability;
+                return *this;
+            }
+    };
+    
     /** A struct for holding statistical information about samples. */
     struct Statistics {
 
@@ -140,7 +233,7 @@ public:
         /** update statistics given new values.
          * @param par Current parameter values.
          * @param obs Current user-define observables values. */
-        void Update(double prob, const std::vector<double>& par, const std::vector<double>& obs);
+        void Update(const ChainState& cs);
     };
 
     /** @} */
@@ -193,11 +286,6 @@ public:
      * @return lag of the Markov chains */
     unsigned GetNLag() const
     { return fMCMCNLag; }
-
-    /**
-     * @return number of iterations */
-    const std::vector<unsigned>& GetNIterations() const
-    { return fMCMCNIterations; }
 
     /**
      * @return current iterations */
@@ -273,33 +361,29 @@ public:
     { return fMCMCProposalFunctionScaleFactor; }
 
     /**
-     * @return current point of each Markov chain */
-    const std::vector<std::vector<double> >& Getx() const
-    { return fMCMCx; }
+     * @param c index of the Markov chain
+     * @return state of chains */
+    const ChainState& GetChainState(unsigned c) const
+    { return fMCMCStates.at(c); }
 
     /**
      * @param c index of the Markov chain
      * @return current point of the Markov chain */
     const std::vector<double>& Getx(unsigned c) const
-    { return fMCMCx.at(c); }
+    { return fMCMCStates.at(c).parameters; }
 
     /**
      * @param c chain index
      * @param p parameter index
      * @return parameter of the Markov chain */
     double Getx(unsigned c, unsigned p) const
-    { return fMCMCx.at(c).at(p); }
-
-    /**
-     * @return log of the probability of the current points of each Markov chain */
-    const std::vector<double>& GetLogProbx() const
-    { return fMCMCprob; }
+    { return fMCMCStates.at(c).parameters.at(p); }
 
     /**
      * @return log of the probability of the current points of the Markov chain.
      * @param c chain index */
     double GetLogProbx(unsigned c) const
-    { return fMCMCprob.at(c); }
+    { return fMCMCStates.at(c).log_probability; }
 
     /**
      * @return pointer to the phase of a run. */
@@ -1198,12 +1282,12 @@ public:
 
     /**
      * Evaluates user-defined observables at current state of all
-     * chains and stores results in fMCMCObservables*/
+     * chains and stores results in fMCMCState*/
     virtual void EvaluateObservables();
 
     /**
      * Evaluates user-defined observables at current state of chain
-     * and stores results in fMCMCObservables
+     * and stores results in fMCMCState
      * @param chain Chain to evaluate observables for. */
     virtual void EvaluateObservables(unsigned chain);
 
@@ -1249,16 +1333,29 @@ public:
 
     /** Generates a new point using the Metropolis algorithm for one chain, varying only one parameter's value
      * @param chain chain index
-     * @param parameter index of parameter to vary
      * @return Whether proposed point was accepted (true) or previous point was kept (false). */
     bool GetNewPointMetropolis(unsigned chain, unsigned parameter);
 
+    /** Accepts or rejects a point for a chain and updates efficiency
+     * @param chain chain index
+     * @param parameter index of parameter to update efficiency for
+     * @return Whether proposed point was accepted (true) or previous point was kept (false). */
+    bool AcceptOrRejectPoint(unsigned chain, unsigned parameter);
+    
     /**
-     * Updates statistics: fill marginalized distributions */
+     * Fill marginalized distributions from a chain state*/
+    void InChainFillHistograms(const ChainState& cs);
+
+    /**
+     * fill marginalized distributions from all chain states*/
     void InChainFillHistograms();
 
     /**
-     * Updates statistics: write chains to file */
+     * Write a chain state to the tree */
+    void InChainFillTree(const ChainState& cs, unsigned chain_number);
+
+    /**
+     * Write all chain states to the tree */
     void InChainFillTree();
 
     /**
@@ -1411,52 +1508,6 @@ public:
     /** @} */
 
 private:
-    /**
-     * Keeps variables that need to be both members and thread local.
-     */
-    struct ThreadLocalStorage {
-        /**
-         * Store local proposal point  */
-        std::vector<double> xLocal;
-
-        /**
-         * Random number generator */
-        TRandom3* rng;
-
-        /**
-         * Temp vector for matrix multiplication in multivariate proposal */
-        TVectorD yLocal;
-
-        /**
-         * Constructor
-         * @param dim Dimension of a temporary parameter vector
-         */
-        ThreadLocalStorage(unsigned dim);
-
-        /**
-         * Copy constructor. */
-        ThreadLocalStorage(const ThreadLocalStorage& other);
-
-        /**
-         * Assignment operator */
-        ThreadLocalStorage& operator = (ThreadLocalStorage other);
-
-        /** swap, can't be a friend this time because this struct is private */
-        void swap(BCEngineMCMC::ThreadLocalStorage& A, BCEngineMCMC::ThreadLocalStorage& B);
-
-        /**
-         * Destructor */
-        virtual ~ThreadLocalStorage();
-
-        /**
-         * Scale a Gaussian random variate such that it becomes a student's t variate;
-         * i.e. return `sqrt(dof / chi2)`, where `chi2` is a variate from a chi2 distribution
-         * with `dof` degrees of freedom.
-         *
-         * If `dof <= 0`, simply return 1 to keep the Gaussian distribution.
-         */
-        double scale(double dof);
-    };
 
     /**
      * Keep thread local variables private. */
@@ -1684,14 +1735,9 @@ protected:
     BCEngineMCMC::Phase fMCMCPhase;
 
     /**
-     * The current points of each Markov chain. */
-    std::vector<std::vector<double> > fMCMCx;
-
-    /**
-     * The current values of the user-defined observables for each
-     * Markov chain. */
-    std::vector<std::vector<double> > fMCMCObservables;
-
+     * The current states of each Markov chain. */
+    std::vector<ChainState> fMCMCStates;
+    
     /**
      * Statistics for each Markov chain. */
     std::vector<BCEngineMCMC::Statistics> fMCMCStatistics;
@@ -1699,21 +1745,6 @@ protected:
     /**
      * Statistics across all Markov chains. */
     BCEngineMCMC::Statistics fMCMCStatistics_AllChains;
-
-    /**
-     * The log of the probability of the current points of each Markov
-     * chain. The length of the vectors is fMCMCNChains. */
-    std::vector<double> fMCMCprob;
-
-    /**
-     * The log of the likelihood of the current points of each Markov
-     * chain. The length of the vectors is fMCMCNChains. */
-    std::vector<double> fMCMCLogLikelihood;
-
-    /**
-     * The log of the likelihood of the proposed points of each Markov
-     * chain. The length of the vectors is fMCMCNChains. */
-    std::vector<double> fMCMCLogLikelihood_Provisional;
 
     /**
      * flag for correcting R value for initial sampling variability. */
@@ -1756,13 +1787,13 @@ protected:
      * flag for whether to reuse MCMC Tree's observables. */
     bool fMCMCTreeReuseObservables;
 
-    unsigned int fMCMCTree_Chain;       ///< (For writing to fMCMCTree) chain number
-    unsigned int fMCMCTree_Iteration;   ///< (For writing to fMCMCTree) iteration number
-    double fMCMCTree_Prob;              ///< (For writing to fMCMCTree) log(posterior)
-    double fMCMCTree_LogLikelihood;     ///< (For writing to fMCMCTree) log(likelihood)
-    double fMCMCTree_LogPrior;          ///< (For writing to fMCMCTree) log(prior)
-    std::vector<double> fMCMCTree_Parameters;   ///< (For writing to fMCMCTree) parameter set
-    std::vector<double> fMCMCTree_Observables;  ///< (For writing to fMCMCTree) observable set
+    /**
+     * MC state object for storing into tree */
+    ChainState fMCMCTree_State;
+
+    /**
+     * Chain number for storing into tree */
+    unsigned int fMCMCTree_Chain;
 
     /**
      * The tree containing the parameter information.*/

--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -96,7 +96,7 @@ public:
 private:
     // grant friendship to BCModel to access the ThreadLocalStorage
     friend class BCModel;
-    
+
     /**
      * Keeps variables that need to be both members and thread local.
      */
@@ -162,30 +162,30 @@ public:
     struct ChainState {
         unsigned iteration;     ///< iteration number
         std::vector<double> parameters; ///< parameter point
-        std::vector<double> observables; ///< observables at parameter point 
+        std::vector<double> observables; ///< observables at parameter point
         double log_probability; ///< log(probability)
         double log_likelihood;  ///< log(likelihood)
         double log_prior;       ///< log(prior)
 
         /** Constructor */
         ChainState(int n_obs = 0) : iteration(0),
-                                    observables(std::vector<double>(n_obs, 0.)),
-                                    log_probability(-std::numeric_limits<double>::infinity()),
-                                    log_likelihood(-std::numeric_limits<double>::infinity()),
-                                    log_prior(-std::numeric_limits<double>::infinity())
-            {}
+            observables(std::vector<double>(n_obs, 0.)),
+            log_probability(-std::numeric_limits<double>::infinity()),
+            log_likelihood(-std::numeric_limits<double>::infinity()),
+            log_prior(-std::numeric_limits<double>::infinity())
+        {}
 
         /** assignment */
         ChainState& operator=(const ThreadLocalStorage& tls)
-            {
-                parameters = tls.parameters;
-                log_prior = tls.log_prior;
-                log_likelihood = tls.log_likelihood;
-                log_probability = tls.log_probability;
-                return *this;
-            }
+        {
+            parameters = tls.parameters;
+            log_prior = tls.log_prior;
+            log_likelihood = tls.log_likelihood;
+            log_probability = tls.log_probability;
+            return *this;
+        }
     };
-    
+
     /** A struct for holding statistical information about samples. */
     struct Statistics {
 
@@ -1341,7 +1341,7 @@ public:
      * @param parameter index of parameter to update efficiency for
      * @return Whether proposed point was accepted (true) or previous point was kept (false). */
     bool AcceptOrRejectPoint(unsigned chain, unsigned parameter);
-    
+
     /**
      * Fill marginalized distributions from a chain state*/
     void InChainFillHistograms(const ChainState& cs);
@@ -1737,7 +1737,7 @@ protected:
     /**
      * The current states of each Markov chain. */
     std::vector<ChainState> fMCMCStates;
-    
+
     /**
      * Statistics for each Markov chain. */
     std::vector<BCEngineMCMC::Statistics> fMCMCStatistics;

--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -1716,16 +1716,6 @@ protected:
     std::vector<double> fMCMCLogLikelihood_Provisional;
 
     /**
-     * The log of the prior of the current points of each Markov
-     * chain. The length of the vectors is fMCMCNChains. */
-    std::vector<double> fMCMCLogPrior;
-
-    /**
-     * The log of the prior of the proposed points of each Markov
-     * chain. The length of the vectors is fMCMCNChains. */
-    std::vector<double> fMCMCLogPrior_Provisional;
-
-    /**
      * flag for correcting R value for initial sampling variability. */
     bool fCorrectRValueForSamplingVariability;
 

--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -38,7 +38,6 @@
 
 #include <algorithm>
 #include <limits>
-#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -1517,7 +1516,10 @@ private:
      * Ensure that there are as many storages as chains */
     void SyncThreadStorage();
 
-    typedef std::map<int, unsigned> ChainIndex_t;
+    /**
+     * Map thread ids to chains. Use vector instead of a map to avoid race
+     * conditions (#258) and because it's more efficient. */
+    typedef std::vector<unsigned> ChainIndex_t;
     ChainIndex_t fChainIndex;
 
     /**

--- a/BAT/BCVariableSet.h
+++ b/BAT/BCVariableSet.h
@@ -305,6 +305,7 @@ public:
         for (unsigned i = 0; i < fVars.size(); ++i)
             BCLog::OutSummary(Form(" %*u) ", n, i) + fVars[i].OneLineSummary(false, fMaxNameLength));
     }
+
 protected:
     /**
      * Vector of BCVariables that forms the set.

--- a/models/base/BCRooInterface.cxx
+++ b/models/base/BCRooInterface.cxx
@@ -324,7 +324,7 @@ void BCRooInterface::MCMCIterationInterface()
                 //_parametersForMarkovChainCurrent->Print();
 
                 const char* paramnamepointer = (tempBCparam.GetName()).c_str();
-                double xij = fMCMCx.at(i).at(j);
+                double xij = Getx(i, j);
                 AddToCurrentChainElement(xij, i, j);
                 RooRealVar* parampointer = (RooRealVar*) & (_parametersForMarkovChainCurrent[paramnamepointer]);
                 parampointer->setVal(xij);

--- a/models/mtf/BCMTF.cxx
+++ b/models/mtf/BCMTF.cxx
@@ -1194,7 +1194,7 @@ void BCMTF::MCMCUserIterationInterface()
         for (int ibin = 1; ibin <= nbins; ++ibin) {
 
             // get expectation value
-            double expectation = Expectation(ichannel, ibin, fMCMCx[0]);
+            double expectation = Expectation(ichannel, ibin, Getx(0));
 
             // fill uncertainty band on expectation
             hist_uncbandexp->Fill(hist_data->GetBinCenter(ibin), expectation);

--- a/src/BCIntegrate.cxx
+++ b/src/BCIntegrate.cxx
@@ -1116,6 +1116,14 @@ std::vector<double> BCIntegrate::FindModeMinuit(std::vector<double>& mode, std::
         return std::vector<double>();
     }
 
+    // set number of chains to be at least one, and call MCMCUserInitialize
+    // allowing the user to make preparations of his or her model if necessary
+    if (GetNChains() == 0)
+        SetNChains(1);
+    MCMCUserInitialize();
+    // set chain number to 0
+    UpdateChainIndex(0);
+    
     // check start values
     if (!start.empty() && start.size() != fParameters.Size()) {
         BCLOG_WARNING("Start point not valid (mismatch of dimensions), set to center.");
@@ -1150,6 +1158,14 @@ std::vector<double> BCIntegrate::FindModeMinuit(std::vector<double>& mode, std::
 // ---------------------------------------------------------
 std::vector<double> BCIntegrate::FindModeSA(std::vector<double>& mode, std::vector<double>& errors, std::vector<double> start)
 {
+    // set number of chains to be at least one, and call MCMCUserInitialize
+    // allowing the user to make preparations of his or her model if necessary
+    if (GetNChains() == 0)
+        SetNChains(1);
+    MCMCUserInitialize();
+    // set chain number to 0
+    UpdateChainIndex(0);
+
     // note: if f(x) is the function to be minimized, then
     // f(x) := - LogEval(parameters)
 

--- a/src/BCIntegrate.cxx
+++ b/src/BCIntegrate.cxx
@@ -1123,7 +1123,7 @@ std::vector<double> BCIntegrate::FindModeMinuit(std::vector<double>& mode, std::
     MCMCUserInitialize();
     // set chain number to 0
     UpdateChainIndex(0);
-    
+
     // check start values
     if (!start.empty() && start.size() != fParameters.Size()) {
         BCLOG_WARNING("Start point not valid (mismatch of dimensions), set to center.");

--- a/src/BCLog.cxx
+++ b/src/BCLog.cxx
@@ -47,6 +47,9 @@ void BCLog::OpenLog(const std::string& filename, BCLog::LogLevel loglevelfile, B
     // suppress the ROOT Info printouts
     gErrorIgnoreLevel = 2000;
 
+    // first close and flush and existing log file
+    BCLog::CloseLog();
+
     // open log file
     BCLog::fOutputStream.open(filename.data());
 

--- a/src/BCModel.cxx
+++ b/src/BCModel.cxx
@@ -92,10 +92,10 @@ double BCModel::LogProbabilityNN(const std::vector<double>& parameters)
     // then calculation likelihood, or set to -inf, if prior already invalid
     double ll = (std::isfinite(lp)) ? LogLikelihood(parameters) : -std::numeric_limits<double>::infinity();;
 
-    if (GetCurrentChain() < fMCMCLogLikelihood_Provisional.size() && GetCurrentChain() < fMCMCLogPrior_Provisional.size()) {
-        fMCMCLogLikelihood_Provisional[GetCurrentChain()] = ll;
-        fMCMCLogPrior_Provisional[GetCurrentChain()] = lp;
-    }
+    unsigned current_chain = GetCurrentChain();
+    if (current_chain < fMCMCLogLikelihood_Provisional.size())
+        fMCMCLogLikelihood_Provisional[current_chain] = ll;
+
     return ll + lp;
 }
 

--- a/src/BCModel.cxx
+++ b/src/BCModel.cxx
@@ -87,18 +87,18 @@ BCModel::~BCModel()
 // ---------------------------------------------------------
 double BCModel::LogProbabilityNN(const std::vector<double>& parameters)
 {
-    unsigned chain = GetCurrentChain();
+    ThreadLocalStorage& s = fMCMCThreadLocalStorage[GetCurrentChain()];
 
     // first calculate prior (which is usually cheaper than likelihood)
-    fMCMCThreadLocalStorage[chain].log_prior = LogAPrioriProbability(parameters);
-    // then calculation likelihood, or set to -inf, if prior already invalid
-    if (std::isfinite(fMCMCThreadLocalStorage[chain].log_prior))
-        fMCMCThreadLocalStorage[chain].log_likelihood = LogLikelihood(parameters);
+    s.log_prior = LogAPrioriProbability(parameters);
+    // then calculate likelihood, or set to -inf, if prior already invalid
+    if (std::isfinite(s.log_prior))
+        s.log_likelihood = LogLikelihood(parameters);
     else
-        fMCMCThreadLocalStorage[chain].log_likelihood = -std::numeric_limits<double>::infinity();
+        s.log_likelihood = -std::numeric_limits<double>::infinity();
 
-    fMCMCThreadLocalStorage[chain].log_probability = fMCMCThreadLocalStorage[chain].log_prior + fMCMCThreadLocalStorage[chain].log_likelihood;
-    return fMCMCThreadLocalStorage[chain].log_probability;
+    s.log_probability = s.log_prior + s.log_likelihood;
+    return s.log_probability;
 }
 
 // ---------------------------------------------------------

--- a/test/BCMath_TEST.cxx
+++ b/test/BCMath_TEST.cxx
@@ -92,11 +92,12 @@ public:
 
             // abuse stats object for one parameter, no observables, dummy probability
             BCEngineMCMC::Statistics s(1, 0);
-            std::vector<double> x(1);
-            std::vector<double> obs;
+            BCEngineMCMC::ChainState cs(0);
+            cs.log_probability = 0.;
+            cs.parameters.assign(1,0);
             for (unsigned i = 0; i < N; ++i) {
-                x.front() = BCMath::Random::Gamma(&rng, a, b);
-                s.Update(0.0, x, obs);
+                cs.parameters.front() = BCMath::Random::Gamma(&rng, a, b);
+                s.Update(cs);
             }
             // 1st moment: O(1/sqrt(N)), 2nd moment: order of magnitude larger
             TEST_CHECK_RELATIVE_ERROR(s.mean.front(), a * b, 1.0 / std::sqrt(N));

--- a/test/BCMath_TEST.cxx
+++ b/test/BCMath_TEST.cxx
@@ -94,7 +94,7 @@ public:
             BCEngineMCMC::Statistics s(1, 0);
             BCEngineMCMC::ChainState cs(0);
             cs.log_probability = 0.;
-            cs.parameters.assign(1,0);
+            cs.parameters.assign(1, 0);
             for (unsigned i = 0; i < N; ++i) {
                 cs.parameters.front() = BCMath::Random::Gamma(&rng, a, b);
                 s.Update(cs);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -38,8 +38,10 @@ TESTS = \
 # The order is determined because parallel and BCSummaryTool also run Markov chains
 # and we want BCEngineMCMC to test that feature first.
 if THREAD_PARALLELIZATION
-BCSummaryTool.log : BCEngineMCMC.log
-parallel.log : BCSummaryTool.log
+parallel.log : BCEngineMCMC.log
+BCModel.log : parallel.log
+BCSummaryTool.log : BCModel.log
+BCFitter.log : BCSummaryTool.log
 endif
 
 LDADD = \

--- a/test/parallel_TEST.cxx
+++ b/test/parallel_TEST.cxx
@@ -160,8 +160,9 @@ public:
         omp_set_dynamic(0);
         omp_set_num_threads(parallelization ? config.num_chains : 1);
 
-        // open log file
-        BCLog::OpenLog("log.txt");
+        // First close previous log, then open a new log file
+        BCLog::CloseLog();
+        BCLog::OpenLog(parallelization ? "log_parallel.txt" : "log_serial.txt");
         BCLog::SetLogLevel(BCLog::detail);
 
         // create new GaussModel object

--- a/test/parallel_TEST.cxx
+++ b/test/parallel_TEST.cxx
@@ -69,9 +69,9 @@ struct BCCheckModel : BCEmptyModel {
 
     TTree* Tree() const {return fMCMCTree;}
 
-    double prob() const {return fMCMCTree_Prob;}
+    double prob() const {return fMCMCTree_State.log_probability;}
     unsigned phase() const {return fMCMCPhase;}
-    const std::vector<double>& parameters() const {return fMCMCTree_Parameters;}
+    const std::vector<double>& parameters() const {return fMCMCTree_State.parameters;}
 };
 
 class RunComparison

--- a/test/parallel_TEST.cxx
+++ b/test/parallel_TEST.cxx
@@ -70,6 +70,8 @@ struct BCCheckModel : BCEmptyModel {
     TTree* Tree() const {return fMCMCTree;}
 
     double prob() const {return fMCMCTree_State.log_probability;}
+    double like() const {return fMCMCTree_State.log_likelihood;}
+    double prior() const {return fMCMCTree_State.log_prior;}
     unsigned phase() const {return fMCMCPhase;}
     const std::vector<double>& parameters() const {return fMCMCTree_State.parameters;}
 };
@@ -267,6 +269,8 @@ public:
             }
 
             TEST_CHECK_EQUAL(models[0].prob(), models[1].prob());
+            TEST_CHECK_EQUAL(models[0].like(), models[1].like());
+            TEST_CHECK_EQUAL(models[0].prior(), models[1].prior());
             TEST_CHECK_EQUAL(models[0].phase(), models[1].phase());
 
             // check only in main run
@@ -321,9 +325,11 @@ public:
 
         RunComparison::Config config = RunComparison::Config::Default();
 
-        config.num_chains = 2;
+        config.num_chains = 4;
         config.num_parameters = 5;
-        config.delay = 1e2;
+        // increase delay to see a speed-up. But some race conditions only show
+        // up with a very fast likelihood
+        config.delay = 0;
 
         TEST_SECTION("product proposal", {
             config.multivariate = false;


### PR DESCRIPTION
This addresses #182 and #205 

I have removed storage of the prior during calculation, since it can be reconstructed via (probability - likelihood). However, we don't even need to store it in the `TTree` as a branch. It could be replaced by an alias---which gets saved with the `TTree`. This has the advantage of lightening the footprint of the tree, but the disadvantage that the alias cannot be loaded into a variable the same way a branch can (via `SetBranchAddress`). It will make no difference for a user who draws directly from the `TTree`, but it will make a difference to someone who accesses it through a macro.

I have not been able to fix #205. But have found that the mismatch is not from the prior. It's actually from the likelihood. `LogProbability` agrees with parameter values stored in the tree; but `LogLikelihood` has occasional discrepancies. --> I am stuck.