### PR TITLE
Smallest Interval bug fixes

### DIFF
--- a/BAT/BCH1D.h
+++ b/BAT/BCH1D.h
@@ -234,6 +234,12 @@ public:
         double relative_mass;
 
         BCH1DInterval();
+
+        /**
+         * Print information to log
+         * @param prefix String to be prepended to every line.
+         * @param prec Precision of doubles to output. */
+        void PrintSummary(const std::string& prefix = "", unsigned prec = 6) const;
     };
 
     /**
@@ -246,6 +252,12 @@ public:
         double max_val;
 
         BCH1DSmallestInterval();
+
+        /**
+         * Print information to log
+         * @param prefix String to be prepended to every line.
+         * @param prec Precision of doubles to output. */
+        void PrintSummary(const std::string& prefix = "", unsigned prec = 6) const;
     };
 
     /**

--- a/src/BCH1D.cxx
+++ b/src/BCH1D.cxx
@@ -456,7 +456,7 @@ std::vector<BCH1D::BCH1DSmallestInterval> BCH1D::GetSmallestIntervals(std::vecto
                 interval.relative_height = GetHistogram()->GetBinContent(b);
                 interval.mode = GetHistogram()->GetBinCenter(b);
                 interval.relative_mass += GetHistogram()->Integral(b, b, "width");
-                while (b < GetHistogram()->GetNbinsX() and GetHistogram()->GetBinContent(b + 1) > bounds[i].first) {
+                while (b < GetHistogram()->GetNbinsX() and GetHistogram()->GetBinContent(b + 1) >= bounds[i].first) {
                     interval.xmax = GetHistogram()->GetXaxis()->GetBinUpEdge(++b);
                     interval.relative_mass += GetHistogram()->Integral(b, b, "width");
                     if (GetHistogram()->GetBinContent(b) > interval.relative_height) {

--- a/src/BCH1D.cxx
+++ b/src/BCH1D.cxx
@@ -426,16 +426,27 @@ void BCH1D::PrintSummary(const std::string& prefix, unsigned prec, std::vector<d
     BCLog::OutSummary(prefix + Form("%2.0f%% quantile:                   %+.*g", 100 * p[6], prec, q[6]));
 
     std::vector<BCH1D::BCH1DSmallestInterval> v = GetSmallestIntervals(intervals);
-    for (unsigned i = 0; i < v.size(); ++i) {
-        BCLog::OutSummary(prefix + Form("Smallest interval%s containing %.1f%% and local mode%s:", (v[i].intervals.size() > 1 ? "s" : ""), 100. * v[i].total_mass, (v[i].intervals.size() > 1 ? "s" : "")));
-        for (unsigned j = 0; j < v[i].intervals.size(); ++j)
-            BCLog::OutSummary(prefix + Form("(%.*g, %.*g) (local mode at %.*g with rel. height %.*g; rel. area %.*g)",
-                                            prec, v[i].intervals[j].xmin,
-                                            prec, v[i].intervals[j].xmax,
-                                            prec, v[i].intervals[j].mode,
-                                            prec, v[i].intervals[j].relative_height,
-                                            prec, v[i].intervals[j].relative_mass));
-    }
+    for (unsigned i = 0; i < v.size(); ++i)
+        v[i].PrintSummary(prefix, prec);
+}
+
+// ---------------------------------------------------------
+void BCH1D::BCH1DSmallestInterval::PrintSummary(const std::string& prefix, unsigned prec) const
+{
+    BCLog::OutSummary(prefix + Form("Smallest interval%s containing %.1f%% and local mode%s:", (intervals.size() > 1 ? "s" : ""), 100. * total_mass, (intervals.size() > 1 ? "s" : "")));
+    for (unsigned i = 0; i < intervals.size(); ++i)
+        intervals[i].PrintSummary(prefix, prec);
+}
+
+// ---------------------------------------------------------
+void BCH1D::BCH1DInterval::PrintSummary(const std::string& prefix, unsigned prec) const
+{
+    BCLog::OutSummary(prefix + Form("(%.*g, %.*g) (local mode at %.*g with rel. height %.*g; rel. area %.*g)",
+                                    prec, xmin,
+                                    prec, xmax,
+                                    prec, mode,
+                                    prec, relative_height,
+                                    prec, relative_mass));
 }
 
 // ---------------------------------------------------------

--- a/src/BCHistogramBase.cxx
+++ b/src/BCHistogramBase.cxx
@@ -438,9 +438,6 @@ std::vector<std::pair<double, double> > BCHistogramBase::GetSmallestIntervalBoun
 // ---------------------------------------------------------
 std::vector<double> BCHistogramBase::GetSmallestIntervalSize(std::vector<double> masses, bool overcoverage)
 {
-    // TO DO : allow for over- vs undercoverage choice
-    (void) overcoverage;
-
     // vector of sizes
     std::vector<double> S;
 
@@ -461,15 +458,12 @@ std::vector<double> BCHistogramBase::GetSmallestIntervalSize(std::vector<double>
 
     S.assign(masses.size(), 0);
     double mass = 0;
-    double area = 0;
-    unsigned n = 0;
-    for (std::vector<std::pair<double, double> >::const_iterator bin = bin_dens_mass.begin(); bin != bin_dens_mass.end() and n < S.size(); ++bin) {
+    for (std::vector<std::pair<double, double> >::const_iterator bin = bin_dens_mass.begin(); bin != bin_dens_mass.end(); ++bin) {
         for (unsigned i = 0; i < masses.size(); ++i)
-            if (mass + bin->second >= masses[i] and mass <= masses[i]) {
-                S[i] = area + (masses[i] - mass) / bin->first;
-                ++n;
-            }
-        area += bin->second / bin->first;
+            // if more mass is needed, add area
+            if (mass + (overcoverage ? 0 : bin->second) < masses[i])
+                S[i] += bin->second / bin->first;
+        mass += bin->second;
     }
     return S;
 }

--- a/test/BCHistogram_TEST.cxx
+++ b/test/BCHistogram_TEST.cxx
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2007-2018, the BAT core developer team
+ * All rights reserved.
+ *
+ * For the licensing terms see doc/COPYING.
+ * For documentation see http://mpp.mpg.de/bat
+ */
+
+#include <test.h>
+
+#include <BAT/BCH1D.h>
+
+#include <TH1D.h>
+#include <TMath.h>
+
+using namespace test;
+
+class BCHistogramTest :
+    public TestCase
+{
+public:
+    BCHistogramTest() :
+        TestCase("BC histogram test")
+    {
+    }
+
+    virtual void run() const
+    {
+        double eps = 1e-6;
+
+        // create a histogram and fill it with Gaus(bin center|0, 1)
+        int N = 10;
+        int x = 5;
+        TH1D h("h", "", (N + 1) * x, -1. * x, 1. * x);
+        for (int b = 1; b <= h.GetNbinsX(); ++b)
+            h.SetBinContent(b, TMath::Gaus(h.GetBinCenter(b)));
+
+        // create BCH1D
+        BCH1D bch(&h);
+
+        double alpha = 0.68;
+
+        /////////////////////////
+        // check for one interval with proper values
+        BCH1D::BCH1DSmallestInterval smallest_interval = bch.GetSmallestIntervals(alpha);
+        TEST_CHECK_EQUAL(smallest_interval.intervals.size(), 1);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].xmin, -1.);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].xmax, +1.);
+        TEST_CHECK_NEARLY_EQUAL(smallest_interval.intervals[0].mode, 0., eps);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].relative_height, 1.);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].relative_mass, 1.);
+
+        /////////////////////////
+        // set peak bin to be exactly equal to threshold for inclusion,
+        // to test that still only one contiguous interval is found
+        int peak_bin = bch.GetHistogram()->GetNbinsX() / 2 + 1;
+        double peak_val = bch.GetHistogram()->GetBinContent(peak_bin);
+        double lower_bound = bch.GetSmallestIntervalBounds(std::vector<double>(1, alpha))[0].second;
+        bch.GetHistogram()->SetBinContent(peak_bin, lower_bound);
+        for (int b = 1; b <= bch.GetHistogram()->GetNbinsX(); ++b)
+            bch.GetHistogram()->SetBinContent(b, bch.GetHistogram()->GetBinContent(b) + (peak_val - lower_bound) / bch.GetHistogram()->GetNbinsX());
+
+        smallest_interval = bch.GetSmallestIntervals(alpha);
+        TEST_CHECK_EQUAL(smallest_interval.intervals.size(), 1);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].xmin, -1.);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].xmax, +1.);
+        TEST_CHECK_NEARLY_EQUAL(smallest_interval.intervals[0].mode, 0., eps);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].relative_height, 1.);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].relative_mass, 1.);
+
+        /////////////////////////
+        // set peak to be below threshold
+        // check for two intervals
+        bch.GetHistogram()->SetBinContent(peak_bin, 0);
+        for (int b = 1; b <= bch.GetHistogram()->GetNbinsX(); ++b)
+            bch.GetHistogram()->SetBinContent(b, bch.GetHistogram()->GetBinContent(b) + lower_bound / bch.GetHistogram()->GetNbinsX());
+
+        smallest_interval = bch.GetSmallestIntervals(alpha);
+        // check there are two intervals
+        TEST_CHECK_EQUAL(smallest_interval.intervals.size(), 2);
+        // check below-peak interval
+        TEST_CHECK_NEARLY_EQUAL(smallest_interval.intervals[0].xmin, -1. - bch.GetHistogram()->GetBinWidth(1), eps);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].xmax, bch.GetHistogram()->GetXaxis()->GetBinUpEdge(peak_bin - 1));
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].mode, bch.GetHistogram()->GetBinCenter(peak_bin - 1));
+        TEST_CHECK_EQUAL(smallest_interval.intervals[0].relative_height, 1.);
+        TEST_CHECK_NEARLY_EQUAL(smallest_interval.intervals[0].relative_mass, 0.5, eps);
+        // check above-peak interval
+        TEST_CHECK_EQUAL(smallest_interval.intervals[1].xmin, bch.GetHistogram()->GetBinLowEdge(peak_bin + 1));
+        TEST_CHECK_NEARLY_EQUAL(smallest_interval.intervals[1].xmax, +1. + bch.GetHistogram()->GetBinWidth(1), eps);
+        TEST_CHECK_EQUAL(smallest_interval.intervals[1].mode, bch.GetHistogram()->GetBinCenter(peak_bin + 1));
+        TEST_CHECK_EQUAL(smallest_interval.intervals[1].relative_height, 1.);
+        TEST_CHECK_NEARLY_EQUAL(smallest_interval.intervals[1].relative_mass, 0.5, eps);
+
+    }
+
+} bchistogram_Test;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,6 +25,7 @@ TESTS = \
 	BCAux.TEST \
 	BCEngineMCMC.TEST \
 	BCFitter.TEST \
+	BCHistogram.TEST \
 	BCMath.TEST \
 	BCModel.TEST \
 	BCParameter.TEST \
@@ -58,6 +59,8 @@ BCAux_TEST_SOURCES = BCAux_TEST.cxx
 BCEngineMCMC_TEST_SOURCES = BCEngineMCMC_TEST.cxx
 
 BCFitter_TEST_SOURCES = BCFitter_TEST.cxx
+
+BCHistogram_TEST_SOURCES = BCHistogram_TEST.cxx
 
 BCMath_TEST_SOURCES = BCMath_TEST.cxx
 

--- a/test/README.md
+++ b/test/README.md
@@ -8,7 +8,7 @@ How to run unit tests
 How to add a new unit test
 ==========================
 
-1. Open `Makefile.am`, add `foo` to `TESTS` and add the sources as `foo_TEST_SOURCES = foo_TEST.cxx`.
+1. Open `Makefile.am`, add `foo.TEST` to `TESTS` and add the sources as `foo_TEST_SOURCES = foo_TEST.cxx`.
 2. Create `foo_TEST.cxx`, enter this skeleton:
 
 ```cpp


### PR DESCRIPTION
Fixes #172, #241 

I did not implement the change [here](https://github.com/talismanbrandi/bat/commit/0613d16b6697d34f86357edd7fc3bd02172d57ce) (`>=` to `>`) because I don't see why we **shouldn't** allow bins that are also equal to the lower bound.