### PR TITLE
Continue running a marginalization in current session

### DIFF
--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -296,8 +296,9 @@ public:
     unsigned GetCurrentChain() const;
 
     /**
-     * @return number of iterations needed for all chains to
-     * converge simultaneously. A value of -1 indicates that the chains did not converge. */
+     * @return number of iterations needed for all chains to converge simultaneously.
+     * A value of -1 indicates that the chains did not converge during a prerun.
+     * A value of 0 indicates that chain criteria were set by hand and convergence was not checked. */
     int GetNIterationsConvergenceGlobal() const
     { return fMCMCNIterationsConvergenceGlobal; }
 
@@ -452,14 +453,9 @@ public:
     { return fCorrectRValueForSamplingVariability; }
 
     /**
-     * @return the flag if MCMC has been performed or not */
+     * @return the if MCMC has been performed or not */
     bool GetFlagRun() const
-    { return fMCMCFlagRun; }
-
-    /**
-     * @return the flag if MCMC pre-run should be performed or not */
-    bool GetFlagPreRun() const
-    { return fMCMCFlagPreRun; }
+    { return fMCMCPhase == kMainRun; }
 
     /**
      * Retrieve the tree containing the Markov chain. */
@@ -966,9 +962,9 @@ public:
     void SetFillHistogramObsPar(const std::string& x, const std::string& y, bool flag = true)
     { SetFillHistogramObsPar(fObservables.Index(x), fParameters.Index(y), flag); }
 
-    /** Sets the flag if a prerun should be performed or not. */
+    /** Set if a (new) prerun should be performed. */
     void SetFlagPreRun(bool flag)
-    { fMCMCFlagPreRun = flag; }
+    { if (flag) fMCMCPhase = kUnsetPhase; }
 
     /**
      * Sets the parameter R-value criterion for convergence of all chains */
@@ -1684,14 +1680,6 @@ protected:
     /**
      * factor to multiply or divide scale factors by in adjusting multivariate-proposal-function scales. */
     double fMultivariateScaleMultiplier;
-
-    /**
-     * Defines if a prerun should be performed or not */
-    bool fMCMCFlagPreRun;
-
-    /**
-     * Defines if MCMC has been performed or not */
-    bool fMCMCFlagRun;
 
     /**
      * The intial position of each Markov chain. The length of the

--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -453,7 +453,7 @@ public:
     { return fCorrectRValueForSamplingVariability; }
 
     /**
-     * @return the if MCMC has been performed or not */
+     * @return if MCMC has been performed or not */
     bool GetFlagRun() const
     { return fMCMCPhase == kMainRun; }
 

--- a/BAT/BCEngineMCMC.h
+++ b/BAT/BCEngineMCMC.h
@@ -1592,11 +1592,6 @@ protected:
     unsigned fMCMCNLag;
 
     /**
-     * Number of total iterations of the Markov chains. The length of
-     * the vector is equal to fMCMCNChains. */
-    std::vector<unsigned> fMCMCNIterations;
-
-    /**
      * The current iteration number. If not called within the running
      * of the algorithm, return -1. */
     int fMCMCCurrentIteration;

--- a/examples/basic/rootOutput/runRootOutput.cxx
+++ b/examples/basic/rootOutput/runRootOutput.cxx
@@ -30,6 +30,10 @@ int main()
     // and all combinations of two parameters
     m.MarginalizeAll();
 
+    // run MCMC for another 100,000 iterations without rerunning the pre-run
+    m.SetNIterationsRun(100000);
+    m.MarginalizeAll();
+
     // if MCMC was run before (MarginalizeAll()) it is
     // possible to use the mode found by MCMC as
     // starting point of Minuit minimization

--- a/test/BCModel_TEST.cxx
+++ b/test/BCModel_TEST.cxx
@@ -45,6 +45,63 @@ public:
                 TEST_CHECK(m.GetMarginalized(i, j).Valid() xor ((i == fixed) or (j == fixed)));
     }
 
+    // check that
+    // 1) one can call MarginalizeAll() several times
+    // 2) one can force the pre-run to be rerun
+    // 3) MarginalizeAll() fails if the model is changed
+    void multiple_runs() const
+    {
+
+        GaussModel m("mult_run", 4);
+        int N = 10000;
+        m.SetPrecision(BCEngineMCMC::kMedium);
+        m.SetNIterationsRun(N);
+
+        m.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        TEST_CHECK_NO_THROW(m.MarginalizeAll(BCIntegrate::kMargMetropolis));
+
+        for (unsigned c = 0; c < m.GetNChains(); ++c)
+            TEST_CHECK_EQUAL(m.GetChainState(c).iteration, 2 * N);
+
+        // Force pre-run to be rerun
+        m.SetFlagPreRun(true);
+        m.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        for (unsigned c = 0; c < m.GetNChains(); ++c)
+            TEST_CHECK_EQUAL(m.GetChainState(c).iteration, N);
+
+        // fix a parameter
+        GaussModel m1("mult_run_1", 4);
+        m1.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        m1.GetParameter(0).Fix(0);
+        TEST_CHECK_THROWS(std::runtime_error, m1.MarginalizeAll(BCIntegrate::kMargMetropolis));
+
+        // add a parameter
+        GaussModel m2("mult_run_2", 4);
+        m2.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        m2.AddParameter("new_parameter", 0, 1);
+        TEST_CHECK_THROWS(std::runtime_error, m2.MarginalizeAll(BCIntegrate::kMargMetropolis));
+
+        // change the number of chains
+        GaussModel m3("mult_run_3", 4);
+        m3.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        m3.SetNChains(2 * m.GetNChains());
+        TEST_CHECK_THROWS(std::runtime_error, m3.MarginalizeAll(BCIntegrate::kMargMetropolis));
+
+        // change from multivariate to factorized proposal
+        GaussModel m4("mult_run_4", 4);
+        m4.SetProposeMultivariate(true);
+        m4.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        m4.SetProposeMultivariate(false);
+        TEST_CHECK_THROWS(std::runtime_error, m4.MarginalizeAll(BCIntegrate::kMargMetropolis));
+
+        // change from factorized to multivariate proposal
+        GaussModel m5("mult_run_5", 4);
+        m5.SetProposeMultivariate(false);
+        m5.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        m5.SetProposeMultivariate(true);
+        TEST_CHECK_THROWS(std::runtime_error, m5.MarginalizeAll(BCIntegrate::kMargMetropolis));
+    }
+
     // turn on/off parameter storing
     void storing() const
     {
@@ -87,6 +144,7 @@ public:
         /* so run again without fixing */
         m.SetName("all free");
         m.GetParameter(0).Unfix();
+        m.SetFlagPreRun(true);
         TEST_CHECK_EQUAL(m.GetNFreeParameters(), 4);
         m.MarginalizeAll();
 
@@ -98,6 +156,7 @@ public:
         m.SetName("fix last");
         fixed = 3;
         m.GetParameter(fixed).Fix(0.23);
+        m.SetFlagPreRun(true);
         count_marginals(m, fixed);
 
         // gaussian around zero with width two
@@ -204,5 +263,8 @@ public:
         fixing(false);
         deltaPrior();
         copy();
+        TEST_SECTION("multiple marginalize", {
+            multiple_runs();
+        });
     }
 } bcmodel_test;

--- a/test/BCModel_TEST.cxx
+++ b/test/BCModel_TEST.cxx
@@ -51,13 +51,12 @@ public:
     // 3) MarginalizeAll() fails if the model is changed
     void multiple_runs() const
     {
-
         GaussModel m("mult_run", 4);
         int N = 10000;
         m.SetPrecision(BCEngineMCMC::kMedium);
         m.SetNIterationsRun(N);
 
-        m.MarginalizeAll(BCIntegrate::kMargMetropolis);
+        TEST_CHECK_NO_THROW(m.MarginalizeAll(BCIntegrate::kMargMetropolis));
         TEST_CHECK_NO_THROW(m.MarginalizeAll(BCIntegrate::kMargMetropolis));
 
         for (unsigned c = 0; c < m.GetNChains(); ++c)


### PR DESCRIPTION
This implements two ways to continue running chains:

1. Calling `MarginalizeAll()` (or `Metropolis()`) a second (or third, etc) time.
2. Loading in a BAT-generated `.root` file instead of running the prerun, and then continuing chains from there.