### PR TITLE
[polynomialFit] Fix clang warning

### DIFF
--- a/examples/advanced/polynomialFit/PolAsymm.cxx
+++ b/examples/advanced/polynomialFit/PolAsymm.cxx
@@ -9,14 +9,14 @@
 
 // ---------------------------------------------------------
 PolAsymm::PolAsymm(const std::string& name, const BCParameterSet& parameters)
-    : BCFitter(TF1(name.c_str(), this, &PolAsymm::FitFunction, 0, 1, parameters.Size()), name)
+    : BCFitter(TF1(name.c_str(), this, &PolAsymm::f, 0, 1, parameters.Size()), name)
 {
     // copy over parameters and all definitions
     fParameters = parameters;
 }
 
 // ---------------------------------------------------------
-double PolAsymm::FitFunction(double* x, double* par)
+double PolAsymm::f(double* x, double* par)
 {
     // n-th order polynomial
     double r = 0;
@@ -43,7 +43,7 @@ double PolAsymm::LogLikelihood(const std::vector<double>& par)
         std::vector<double>& x = GetDataSet()->GetDataPoint(i).GetValues();
 
         // calculate the value of the function at this point
-        double y_func = FitFunction(&x[0], parRoot);
+        double y_func = f(&x[0], parRoot);
 
         // Likelihood *= asymmetric Gaussian evaluated at y_func given
         // mode from the data point (x[1]) and standard deviation

--- a/examples/advanced/polynomialFit/PolAsymm.h
+++ b/examples/advanced/polynomialFit/PolAsymm.h
@@ -30,7 +30,7 @@ public:
     {}
 
     // fit function returning expectation value for each data point
-    virtual double FitFunction(double* x, double* par);
+    double f(double* x, double* par);
 
     // loglikelihood function - probability of the data given the parameters
     double LogLikelihood(const std::vector<double>& par);


### PR DESCRIPTION
I checked for compiler warnings with different compilers with

    ./configure --disable-static --enable-debug --enable-silent-rules --with-cuba=download --enable-roostats CXX=clang++-3.8

With this commit, I get no more warnings with ROOT6. Same result with g++7.2. Only  with ROOT5, there are warnings for every BAT library but we won't fix that, it's ROOT internal

```
  CXX      libBATmodels_rdict.lo
libBATmodels_rdict.cxx:11:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]
        ^
libBATmodels_rdict.cxx:12:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]
        ^
In file included from libBATmodels_rdict.cxx:17:
In file included from ./libBATmodels_rdict.h:18:
/usr/include/root/G__ci.h:968:9: warning: keyword is hidden by macro definition [-Wkeyword-macro]
        ^
3 warnings generated.
```