### PR TITLE
[install, tools] Reduce minimal ax_openmp autoconf version to 2.59

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,8 +35,8 @@ release, some more packages are needed
 
     sudo apt-get install autoconf automake git-core libtool
 
-Building and installing works with automake >= 1.10. To run the tests, a more
-recent version is needed, v1.15 is known to be sufficient.
+Building and installing works with autoconf >= 2.63 and automake >= 1.10. To run
+the tests, a more recent version is needed, v1.15 is known to be sufficient.
 
 ### Required: ROOT
 

--- a/test/BCModel_TEST.cxx
+++ b/test/BCModel_TEST.cxx
@@ -17,6 +17,8 @@
 #include <BAT/BCH2D.h>
 #include <BAT/BCParameter.h>
 
+#include <stdexcept>
+
 using namespace test;
 
 class BCModelTest :

--- a/test/BCModel_TEST.cxx
+++ b/test/BCModel_TEST.cxx
@@ -52,7 +52,7 @@ public:
     void multiple_runs() const
     {
         GaussModel m("mult_run", 4);
-        int N = 10000;
+        unsigned N = 10000;
         m.SetPrecision(BCEngineMCMC::kMedium);
         m.SetNIterationsRun(N);
 

--- a/test/parallel_TEST.cxx
+++ b/test/parallel_TEST.cxx
@@ -204,7 +204,7 @@ public:
 
     }
 
-    void Check() throw(TestCaseFailedException)
+    void Check()
     {
         // check if files were written
         {

--- a/tools/build/ax_openmp.m4
+++ b/tools/build/ax_openmp.m4
@@ -70,7 +70,8 @@
 #serial 13
 
 AC_DEFUN([AX_OPENMP], [
-AC_PREREQ([2.69]) dnl for _AC_LANG_PREFIX
+# Frederik Beaujean: Reduced from 2.69 to 2.59, an earlier version of this macro had that version as required for _AC_LANG_PREFIX
+AC_PREREQ([2.59]) dnl for _AC_LANG_PREFIX
 
 AC_CACHE_CHECK([for OpenMP flag of _AC_LANG compiler], ax_cv_[]_AC_LANG_ABBREV[]_openmp, [save[]_AC_LANG_PREFIX[]FLAGS=$[]_AC_LANG_PREFIX[]FLAGS
 ax_cv_[]_AC_LANG_ABBREV[]_openmp=unknown


### PR DESCRIPTION
Fixes #286 and #285 

@greenwald  please test that this works on your system with an old version of autoconf