### PR TITLE
Revert "[configure] Set U flag for cuba archive generation"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,10 +133,6 @@ elif test "$with_cuba" = "download"; then
       AC_MSG_ERROR([Need either wget or curl to download Cuba.])
     fi
 
-    # Fix #248
-    ARFLAGS_OLD=ARFLAGS
-    export ARFLAGS=rvU
-
     mkdir -p "${local_cuba_dir}" \
     && (${download_cmd} "${cuba_url}" | tar --strip-components 1 -C "${local_cuba_dir}" --strip=1 -x -z) \
     && (
@@ -144,7 +140,6 @@ elif test "$with_cuba" = "download"; then
       && CFLAGS="-fPIC -O3 -fomit-frame-pointer -ffast-math -Wall" ./configure \
       && make lib
     )
-    ARFLAGS=ARFLAGS_OLD
   else
     AC_MSG_NOTICE([Reusing existing local cuba build in $local_cuba_dir])
   fi


### PR DESCRIPTION
This reverts commit b181c39916fe3fc1235dfb3f01c00fdd52a8e444.

The U flag removed ignorable warnings with newer `ar` versions but leads to an
error with old `ar` versions that don't know this flag yet. From a user `configure.log`

```
/nfs/mnemosyne/sys/slc6/contrib/gcc/4.9.1/bin/gcc -std=gnu11 -fPIC -O3 -fomit-frame-pointer -ffast-math -Wall -DHAVE_CONFIG_H -DREALSIZE=8 -I./src/common -I. -I. -I./src/vegas -DNOUNDERSCORE -c -o Vegas.o ./src/vegas/Vegas.c
ar rvU libcuba.a Vegas.o
ar: illegal option -- U
Usage: ar [emulation options] [-]{dmpqrstx}[abcfilNoPsSuvV] [member-name] [count] archive-file file...
       ar -M [<mri-script]
 commands:
  d            - delete file(s) from the archive
  m[ab]        - move file(s) in the archive
  p            - print file(s) found in the archive
  q[f]         - quick append file(s) to the archive
  r[ab][f][u]  - replace existing or insert new file(s) into the archive
  t            - display contents of archive
  x[o]         - extract file(s) from the archive
 command specific modifiers:
  [a]          - put file(s) after [member-name]
  [b]          - put file(s) before [member-name] (same as [i])
  [D]          - use zero for timestamps and uids/gids
  [N]          - use instance [count] of name
  [f]          - truncate inserted file names
  [P]          - use full path names when matching
  [o]          - preserve original dates
  [u]          - only replace files that are newer than current archive contents
 generic modifiers:
  [c]          - do not warn if the library had to be created
  [s]          - create an archive index (cf. ranlib)
  [S]          - do not build a symbol table
  [T]          - make a thin archive
  [v]          - be verbose
  [V]          - display the version number
  @<file>      - read options from <file>
 emulation options:
  No emulation specific options
ar: supported targets: elf64-x86-64 elf32-i386 a.out-i386-linux pei-i386 pei-x86-64 elf64-l1om elf64-little elf64-big elf32-little elf32-big srec symbolsrec verilog tekhex binary ihex
make: *** [libcuba.a(Vegas.o)] Error 1
checking for cuba.h in /nfs/freenas/tuph/e18/project/e18sat/SIM/batv1_0/bat-1.0.0-RC2/external/cuba-4.2
checking for cuba.h... yes
checking for cuba library in path /nfs/freenas/tuph/e18/project/e18sat/SIM/batv1_0/bat-1.0.0-RC2/external/cuba-4.2
detected cuba matching the interface of version 4.1
checking for main in -lcuba... no
configure: error: Could not find libcuba.a; use --with-cuba-lib-dir=DIR or compile without cuba
```