### PR TITLE
Style refactor

### DIFF
--- a/BAT/BCAux.h
+++ b/BAT/BCAux.h
@@ -67,10 +67,6 @@ private:
 };
 
 /**
- * Sets the default BAT style for drawing plots. */
-void SetStyle();
-
-/**
  * Force file extension to be .pdf if not already .pdf or .ps
  * @param filename Filename to be altered */
 void DefaultToPDF(std::string& filename);

--- a/BAT/BCAux.h
+++ b/BAT/BCAux.h
@@ -67,6 +67,10 @@ private:
 };
 
 /**
+ * @deprecated This function is empty but for a warning message. Please do not call it. */
+void SetStyle();
+
+/**
  * Force file extension to be .pdf if not already .pdf or .ps
  * @param filename Filename to be altered */
 void DefaultToPDF(std::string& filename);

--- a/benchmarks/PerfTestSuite/src/PerfTest1DFunction.cxx
+++ b/benchmarks/PerfTestSuite/src/PerfTest1DFunction.cxx
@@ -16,8 +16,6 @@
 #include <TGraph.h>
 
 #include <BAT/BCH1D.h>
-#include <BAT/BCAux.h>
-#include <BAT/BCMath.h>
 
 #include <iostream>
 
@@ -30,9 +28,6 @@ PerfTest1DFunction::PerfTest1DFunction(const std::string& name, TF1* func)
 {
     // set test type
     fTestType = PerfTest::kFunction1D;
-
-    // set style
-    BCAux::SetStyle();
 
     // manipulate function
     fFunction->SetNDF(100000);

--- a/benchmarks/PerfTestSuite/src/PerfTest2DFunction.cxx
+++ b/benchmarks/PerfTestSuite/src/PerfTest2DFunction.cxx
@@ -13,7 +13,6 @@
 #include <TStyle.h>
 
 #include <BAT/BCH2D.h>
-#include <BAT/BCAux.h>
 
 #include <stdexcept>
 #include <iostream>
@@ -27,9 +26,6 @@ PerfTest2DFunction::PerfTest2DFunction(const std::string& name, TF2* func)
 {
     // set test type
     fTestType = PerfTest::kFunction2D;
-
-    // set style
-    BCAux::SetStyle();
 
     // manipulate function
     fFunction->SetNDF(100000);

--- a/examples/advanced/advancedGraphFitter/graphFitterAdvancedExample.C
+++ b/examples/advanced/advancedGraphFitter/graphFitterAdvancedExample.C
@@ -31,7 +31,6 @@
 // run the macro in both normal and compiled mode.
 #if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
-#include <BAT/BCAux.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCGraphFitter.h>
 
@@ -56,9 +55,6 @@ void graphFitterAdvancedExample()
 {
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
 
     // -------------------------
     // Prepare fitting functions

--- a/examples/advanced/mtf/ensembleTest/ensembleTest.C
+++ b/examples/advanced/mtf/ensembleTest/ensembleTest.C
@@ -29,7 +29,6 @@
 // run the macro in both normal and compiled mode.
 #if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
-#include <BAT/BCAux.h>
 #include <BAT/BCGaussianPrior.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCParameter.h>
@@ -47,13 +46,8 @@
 
 void ensembleTest()
 {
-    // ---- set style and open log files ---- //
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
 
     // ---- read histograms from a file ---- //
 

--- a/examples/advanced/mtf/mcstat/mcstat.C
+++ b/examples/advanced/mtf/mcstat/mcstat.C
@@ -29,7 +29,6 @@
 // run the macro in both normal and compiled mode.
 #if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
-#include <BAT/BCAux.h>
 #include <BAT/BCEngineMCMC.h>
 #include <BAT/BCGaussianPrior.h>
 #include <BAT/BCLog.h>
@@ -49,14 +48,8 @@
 
 void mcstat()
 {
-    // ---- set style and open log files ---- //
-
     // open log file
-    BCLog::OpenLog("log.txt");
-    BCLog::SetLogLevel(BCLog::detail);
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
+    BCLog::OpenLog("log.txt", BCLog::detail);
 
     // ---- read histograms from a file ---- //
 

--- a/examples/advanced/mtf/singleChannel/singleChannel.C
+++ b/examples/advanced/mtf/singleChannel/singleChannel.C
@@ -29,7 +29,6 @@
 // run the macro in both normal and compiled mode.
 #if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
-#include <BAT/BCAux.h>
 #include <BAT/BCGaussianPrior.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCMTF.h>
@@ -45,13 +44,8 @@
 
 void singleChannel()
 {
-    // ---- set style and open log files ---- //
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
 
     // ---- read histograms from a file ---- //
 

--- a/examples/advanced/mtf/systematics/runSystematics.cxx
+++ b/examples/advanced/mtf/systematics/runSystematics.cxx
@@ -1,4 +1,3 @@
-#include <BAT/BCAux.h>
 #include <BAT/BCGaussianPrior.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCParameter.h>
@@ -13,24 +12,18 @@
 
 int main()
 {
-    // ---- set style and open log files ---- //
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
-    BCLog::OpenLog("log.txt");
-    BCLog::SetLogLevel(BCLog::detail);
+    BCLog::OpenLog("log.txt", BCLog::detail);
 
     // ---- read histograms from a file ---- //
 
     // open file
     std::string fname = "templates.root";
-    TFile* file = TFile::Open(fname.c_str(), "READ");
+    TFile* file = TFile::Open(fname.data(), "READ");
 
     // check if file is open
     if (!file || file->IsZombie()) {
-        BCLog::OutError(Form("Could not open file %s.", fname.c_str()));
+        BCLog::OutError(Form("Could not open file %s.", fname.data()));
         BCLog::OutError("Run macro CreateHistograms.C in Root to create the file.");
         return 1;
     }

--- a/examples/advanced/mtf/twoChannels/twoChannels.C
+++ b/examples/advanced/mtf/twoChannels/twoChannels.C
@@ -29,7 +29,6 @@
 // run the macro in both normal and compiled mode.
 #if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
-#include <BAT/BCAux.h>
 #include <BAT/BCGaussianPrior.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCMTF.h>
@@ -45,13 +44,8 @@
 
 void twoChannels()
 {
-    // ---- set style and open log files ---- //
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
 
     // ---- read histograms from a file ---- //
 

--- a/examples/advanced/polynomialFit/asymmErrorsFitterExample.cxx
+++ b/examples/advanced/polynomialFit/asymmErrorsFitterExample.cxx
@@ -14,9 +14,6 @@
 
 int main()
 {
-    // set nice style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file with default level of logging
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::summary);
 

--- a/examples/advanced/referenceCounting/runReferenceCounting.cxx
+++ b/examples/advanced/referenceCounting/runReferenceCounting.cxx
@@ -12,9 +12,6 @@
 
 int main()
 {
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/examples/advanced/referenceCounting/runReferenceCounting.cxx
+++ b/examples/advanced/referenceCounting/runReferenceCounting.cxx
@@ -19,7 +19,7 @@ int main()
     BCMath::CacheFactorials(1000);
 
     // create new ReferenceCounting object for 20 measured events
-    ReferenceCounting m("refcountMod", 20);
+    ReferenceCounting m("Reference Counting", 20);
 
     // set background expectation
     double bkg_exp = 10; // expectation value
@@ -44,14 +44,14 @@ int main()
     m.FindMode(m.GetBestFitParameters());
 
     // draw all marginalized distributions into a pdf file
-    m.PrintAllMarginalized("ReferenceCounting_plots.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
     m.GetBCH1DdrawingOptions().SetLogy();
-    m.PrintAllMarginalized("ReferenceCounting_logy.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_logy.pdf");
 
     // print knowledge update with detailed posteriors
     m.SetKnowledgeUpdateDrawingStyle(BCAux::kKnowledgeUpdateDetailedPosterior);
     m.GetBCH2DPosteriorDrawingOptions().SetNSmooth(0);
-    m.PrintKnowledgeUpdatePlots("ReferenceCounting_update.pdf");
+    m.PrintKnowledgeUpdatePlots(m.GetSafeName() + "_update.pdf");
 
     // print results of the analysis to the log
     m.PrintSummary();

--- a/examples/advanced/rooInterface/runRooInterface.cxx
+++ b/examples/advanced/rooInterface/runRooInterface.cxx
@@ -1,6 +1,5 @@
 #include <BAT/BCRooInterface.h>
 
-#include <BAT/BCAux.h>
 #include <BAT/BCH1D.h>
 #include <BAT/BCH2D.h>
 #include <BAT/BCLog.h>
@@ -57,12 +56,8 @@ int main(int argc, char** argv)
     std::cout << "The inputs will be retrieved from " << rootFile << " (workspace " << wsName << ") and the posterior probability plot will be stored in " << outputFile << std::endl;
     std::cout << nMCMC << " MCMC iteration will be performed\n";
 
-    // set nice style for drawing than the ROOT default
-    BCAux::SetStyle();
-
-    // open log file with default level of logging
-    BCLog::OpenLog(logFile);
-    BCLog::SetLogLevel(BCLog::detail);
+    // open log file
+    BCLog::OpenLog(logFile, BCLog::detail);
 
     // create new RooFit-based model
     BCRooInterface _myRooInterface;

--- a/examples/advanced/trialFunction/runTrialFunction.cxx
+++ b/examples/advanced/trialFunction/runTrialFunction.cxx
@@ -1,13 +1,9 @@
-#include <BAT/BCAux.h>
 #include <BAT/BCLog.h>
 
 #include "GaussModel.h"
 
 int main()
 {
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
 
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);

--- a/examples/advanced/trialFunction/runTrialFunction.cxx
+++ b/examples/advanced/trialFunction/runTrialFunction.cxx
@@ -9,7 +9,7 @@ int main()
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 
     // create new GaussModel object
-    GaussModel m("gausMod");
+    GaussModel m("Gauss Model");
 
     // set marginalization method
     m.SetMarginalizationMethod(BCIntegrate::kMargMetropolis);
@@ -30,7 +30,7 @@ int main()
     m.FindMode(m.GetBestFitParameters());
 
     // draw all marginalized distributions into a PostScript file
-    m.PrintAllMarginalized("GaussModel_plots.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
 
     // print results of the analysis to the log
     m.PrintSummary();

--- a/examples/basic/binomial/runEfficiency.cxx
+++ b/examples/basic/binomial/runEfficiency.cxx
@@ -1,14 +1,9 @@
 #include <BAT/BCLog.h>
-#include <BAT/BCAux.h>
 
 #include "BinomialModel.h"
 
 int main()
 {
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/examples/basic/binomial/runEfficiency.cxx
+++ b/examples/basic/binomial/runEfficiency.cxx
@@ -17,7 +17,7 @@ int main()
     m.FindMode(m.GetBestFitParameters());
 
     // draw all marginalized distributions into a pdf file
-    m.PrintAllMarginalized("BinomialModel_plots.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
 
     // print results of the analysis to the log
     m.PrintSummary();

--- a/examples/basic/combination1d/runCombineGaussians.cxx
+++ b/examples/basic/combination1d/runCombineGaussians.cxx
@@ -20,11 +20,11 @@ int main()
     m.FindMode(m.GetBestFitParameters());
 
     // draw all marginalized distributions into a PostScript file
-    m.PrintAllMarginalized("CombinationModel_plots.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
 
     // print knowledge update plot, with detailed posterior
     m.SetKnowledgeUpdateDrawingStyle(BCAux::kKnowledgeUpdateDetailedPosterior);
-    m.PrintKnowledgeUpdatePlots("CombinationModel_update.pdf");
+    m.PrintKnowledgeUpdatePlots(m.GetSafeName() + "_update.pdf");
 
     // print results of the analysis to the log
     m.PrintSummary();

--- a/examples/basic/combination1d/runCombineGaussians.cxx
+++ b/examples/basic/combination1d/runCombineGaussians.cxx
@@ -5,10 +5,6 @@
 
 int main()
 {
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/examples/basic/combination2d/runCombineGaussians.cxx
+++ b/examples/basic/combination2d/runCombineGaussians.cxx
@@ -23,11 +23,11 @@ int main()
     m.PrintAllMarginalized("CombinationModel_plots.pdf");
 
     // print summary plots
-    m.PrintParameterPlot("CombinationModel_parameters.pdf");
-    m.PrintCorrelationPlot("CombinationModel_correlation.pdf");
+    m.PrintParameterPlot(m.GetSafeName() + "_parameters.pdf");
+    m.PrintCorrelationPlot(m.GetSafeName() + "_correlation.pdf");
 
     // m.SetKnowledgeUpdateDrawingStyle(BCAux::kKnowledgeUpdateDetailedPosterior);
-    m.PrintKnowledgeUpdatePlots("CombinationModel_update.pdf");
+    m.PrintKnowledgeUpdatePlots(m.GetSafeName() + "_update.pdf");
 
     // print results of the analysis the log
     m.PrintSummary();

--- a/examples/basic/combination2d/runCombineGaussians.cxx
+++ b/examples/basic/combination2d/runCombineGaussians.cxx
@@ -1,14 +1,10 @@
 #include <BAT/BCLog.h>
-#include <BAT/BCAux.h>
+//#include <BAT/BCAux.h>
 
 #include "CombinationModel.h"
 
 int main()
 {
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/examples/basic/efficiencyFitter/efficiencyFitterExample.C
+++ b/examples/basic/efficiencyFitter/efficiencyFitterExample.C
@@ -36,7 +36,6 @@
 #include <TCanvas.h>
 #include <TRandom3.h>
 
-#include <BAT/BCAux.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCEfficiencyFitter.h>
 
@@ -47,9 +46,6 @@ void efficiencyFitterExample()
 {
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
-
-    // set style
-    BCAux::SetStyle();
 
     // -------------------------
     // define the fit function, which is also used in the generation of the data

--- a/examples/basic/errorPropagation/runErrorPropagation.cxx
+++ b/examples/basic/errorPropagation/runErrorPropagation.cxx
@@ -8,7 +8,7 @@ int main()
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 
     // create new RatioModel object
-    RatioModel m("ratMod");
+    RatioModel m("Ratio Model");
 
     // set Metropolis as marginalization method
     m.SetMarginalizationMethod(BCIntegrate::kMargMetropolis);
@@ -23,7 +23,7 @@ int main()
     m.FindMode(m.GetBestFitParameters());
 
     // draw all marginalized distributions into a PostScript file
-    m.PrintAllMarginalized("RatioModel_plots.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
 
     // print results of the analysis to the log
     m.PrintSummary();

--- a/examples/basic/errorPropagation/runErrorPropagation.cxx
+++ b/examples/basic/errorPropagation/runErrorPropagation.cxx
@@ -1,14 +1,9 @@
 #include <BAT/BCLog.h>
-#include <BAT/BCAux.h>
 
 #include "RatioModel.h"
 
 int main()
 {
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/examples/basic/graphFitter/graphFitterSimpleExample.C
+++ b/examples/basic/graphFitter/graphFitterSimpleExample.C
@@ -36,7 +36,6 @@
 #include <TCanvas.h>
 #include <TRandom3.h>
 
-#include <BAT/BCAux.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCGraphFitter.h>
 
@@ -52,9 +51,6 @@ void graphFitterSimpleExample()
 {
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
 
     // -------------------------
     // define a fit function, also used to create data

--- a/examples/basic/histogramFitter/histogramFitterExample.C
+++ b/examples/basic/histogramFitter/histogramFitterExample.C
@@ -30,7 +30,6 @@
 // run the macro in both normal and compiled mode.
 #if defined(__MAKECINT__) || defined(__ROOTCLING__) || (!defined(__CINT__) && !defined(__CLING__))
 
-#include <BAT/BCAux.h>
 #include <BAT/BCLog.h>
 #include <BAT/BCHistogramFitter.h>
 
@@ -49,11 +48,7 @@
 void histogramFitterExample()
 {
     // open log file
-    BCLog::OpenLog("log.txt");
-    BCLog::SetLogLevel(BCLog::detail);
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
+    BCLog::OpenLog("log.txt", BCLog::detail);
 
     // -------------------------
     // Create data

--- a/examples/basic/poisson/runPoissonCounting.cxx
+++ b/examples/basic/poisson/runPoissonCounting.cxx
@@ -1,13 +1,9 @@
 #include "PoissonModel.h"
 
-#include <BAT/BCAux.h>
 #include <BAT/BCLog.h>
 
 int main()
 {
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/examples/basic/poisson/runPoissonCounting.cxx
+++ b/examples/basic/poisson/runPoissonCounting.cxx
@@ -8,7 +8,7 @@ int main()
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 
     // create new PoissonModel object
-    PoissonModel m("poisMod");
+    PoissonModel m("Poison Model");
 
     // set number of observed events
     m.SetNObs(7);
@@ -21,7 +21,7 @@ int main()
     m.FindMode(m.GetBestFitParameters());
 
     // draw all marginalized distributions into a PDF file
-    m.PrintAllMarginalized("PoissonModel_plots.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
 
     // print summary to the log
     m.PrintSummary();

--- a/examples/basic/rootOutput/readRootOutput.cxx
+++ b/examples/basic/rootOutput/readRootOutput.cxx
@@ -1,4 +1,3 @@
-#include <BAT/BCAux.h>
 #include <BAT/BCH1D.h>
 #include <BAT/BCH2D.h>
 #include <BAT/BCEmptyModel.h>
@@ -8,10 +7,6 @@
 
 int main()
 {
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/examples/basic/rootOutput/readRootOutput.cxx
+++ b/examples/basic/rootOutput/readRootOutput.cxx
@@ -14,7 +14,7 @@ int main()
     // empty string for second argument tells BAT to search for model in file.
     // If you run the example repeatedly, results are added.
     // To avoid errors, we give the name of the model explicitly.
-    BCEmptyModel m("GaussModel.root", "gausMod");
+    BCEmptyModel m("GaussModel.root", "GaussModel");
 
     m.Remarginalize();
 
@@ -40,7 +40,7 @@ int main()
     h01.Draw();
 
     C.Update();
-    C.Print("GaussModel_loaded_plots.pdf");
+    C.Print((m.GetSafeName() + "_loaded_plots.pdf").data());
 
     // close log file
     BCLog::CloseLog();

--- a/examples/basic/rootOutput/runRootOutput.cxx
+++ b/examples/basic/rootOutput/runRootOutput.cxx
@@ -10,7 +10,7 @@ int main()
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 
     // create new GaussModel object
-    GaussModel m("gausMod");
+    GaussModel m("Gauss Model");
 
     // set marginalization method
     m.SetMarginalizationMethod(BCIntegrate::kMargMetropolis);
@@ -19,7 +19,7 @@ int main()
     m.SetPrecision(BCEngineMCMC::kMedium);
 
     // switch writing of Markov Chains on
-    m.WriteMarkovChain("GaussModel.root", "RECREATE");
+    m.WriteMarkovChain(m.GetSafeName() + ".root", "RECREATE");
 
     // run MCMC and marginalize posterior wrt. all parameters
     // and all combinations of two parameters
@@ -35,13 +35,13 @@ int main()
     m.FindMode(m.GetBestFitParameters());
 
     // draw all marginalized distributions into a PostScript file
-    m.PrintAllMarginalized("GaussModel_plots.pdf");
+    m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
 
     // print results of the analysis to the log
     m.PrintSummary();
 
     // write marginalized distributions to output file
-    m.WriteMarginalizedDistributions("GaussModel.root", "UPDATE");
+    m.WriteMarginalizedDistributions(m.GetSafeName() + ".root", "UPDATE");
 
     // close log file
     BCLog::CloseLog();

--- a/examples/basic/rootOutput/runRootOutput.cxx
+++ b/examples/basic/rootOutput/runRootOutput.cxx
@@ -1,5 +1,4 @@
 #include <BAT/BCLog.h>
-#include <BAT/BCAux.h>
 
 #include "GaussModel.h"
 
@@ -7,10 +6,6 @@
 
 int main()
 {
-
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/models/base/BCEfficiencyFitter.cxx
+++ b/models/base/BCEfficiencyFitter.cxx
@@ -178,7 +178,6 @@ void BCEfficiencyFitter::DrawData(bool flaglegend)
         legend->SetFillColor(0);
         legend->SetFillStyle(0);
         legend->SetTextAlign(12);
-        legend->SetTextFont(62);
         legend->SetTextSize(0.03);
         legend->SetNColumns(2);
         legend->SetColumnSeparation(5e-2);
@@ -256,7 +255,6 @@ void BCEfficiencyFitter::DrawFit(const std::string& options, bool flaglegend)
         legend->SetFillColor(0);
         legend->SetFillStyle(0);
         legend->SetTextAlign(12);
-        legend->SetTextFont(62);
         legend->SetTextSize(0.03);
         legend->SetNColumns(3);
         legend->SetColumnSeparation(5e-2);

--- a/src/BCAux.cxx
+++ b/src/BCAux.cxx
@@ -27,6 +27,10 @@
 #include <limits>
 
 // ---------------------------------------------------------
+void BCAux::SetStyle()
+{
+    BCLog::OutWarning("BCAux::SetStyle() is deprecated and no longer does anything. Please do not use it.");
+}
 
 // ---------------------------------------------------------
 void BCAux::DefaultToPDF(std::string& filename)

--- a/src/BCAux.cxx
+++ b/src/BCAux.cxx
@@ -219,8 +219,8 @@ void BCAux::SetKnowledgeUpdateDrawingStyle(BCH2D& prior, BCH2D& posterior, BCAux
             posterior.SetColorScheme(BCHistogramBase::kBlackWhite);
             posterior.SetNLegendColumns(1);
             posterior.SetLineWidth(2);
-            prior.CopyOptions(posterior);
             posterior.SetLocalModeMarkerStyle(21);
+            prior.CopyOptions(posterior);
             prior.SetLineColor(kGray + 1);
             prior.SetMarkerColor(kGray + 1);
             break;
@@ -299,7 +299,7 @@ void BCAux::DrawKnowledgeUpdate(BCHistogramBase& prior, BCHistogramBase& posteri
 
     // create / draw legend(s)
 
-    if (prior.GetLegend().GetNRows() > 0)
+    if (prior.GetHistogram()->GetDimension() > 1 or prior.GetLegend().GetNRows() > 0)
         prior.GetLegend().SetHeader(prior.GetHistogram()->GetTitle());
     else
         prior.GetLegend().AddEntry(prior.GetHistogram(), 0, "L");

--- a/src/BCAux.cxx
+++ b/src/BCAux.cxx
@@ -14,14 +14,12 @@
 
 #include <TCanvas.h>
 #include <TDirectory.h>
-#include <TGaxis.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TLegend.h>
 #include <TLegendEntry.h>
 #include <TList.h>
 #include <TPad.h>
-#include <TStyle.h>
 
 #include <algorithm>
 #include <cmath>
@@ -29,90 +27,6 @@
 #include <limits>
 
 // ---------------------------------------------------------
-
-void BCAux::SetStyle()
-{
-    // pads
-    gStyle->SetPadTopMargin   (0.05);
-    gStyle->SetPadBottomMargin(0.11);
-    gStyle->SetPadLeftMargin  (0.15);
-    gStyle->SetPadRightMargin (0.10);
-    gStyle->SetPadBorderMode  (0);
-
-    // canvases
-    gStyle->SetCanvasColor     (kWhite);
-    gStyle->SetCanvasBorderMode(0);
-    gStyle->SetCanvasDefH      (700);
-    gStyle->SetCanvasDefW      ((int)(700.*(1. - gStyle->GetPadTopMargin() - gStyle->GetPadBottomMargin()) / (1. - gStyle->GetPadLeftMargin() - gStyle->GetPadRightMargin())));
-
-    // Frames
-    gStyle->SetFrameFillStyle (0);
-    gStyle->SetFrameFillColor (kWhite);
-    gStyle->SetFrameLineColor (kBlack);
-    gStyle->SetFrameLineStyle (0);
-    gStyle->SetFrameLineWidth (1);
-    gStyle->SetFrameBorderMode(0);
-
-    // histograms
-    gStyle->SetHistFillColor(kWhite);
-    gStyle->SetHistFillStyle(0);
-    gStyle->SetHistLineColor(kBlack);
-    gStyle->SetHistLineStyle(0);
-    gStyle->SetHistLineWidth(1);
-    gStyle->SetStripDecimals(kFALSE);
-
-    // set decimals
-    TGaxis::SetMaxDigits(4);
-
-    // options
-    gStyle->SetOptTitle(0);
-
-    // lines
-    gStyle->SetLineColor(kBlack);
-    gStyle->SetLineStyle(1);
-    gStyle->SetLineWidth(1);
-
-    // markers
-    gStyle->SetMarkerStyle(kFullCircle);
-    gStyle->SetMarkerSize (1.0);
-
-    // functions
-    gStyle->SetFuncColor(kBlack);
-    gStyle->SetFuncStyle(0);
-    gStyle->SetFuncWidth(2);
-
-    // labels
-    gStyle->SetLabelFont(62,     "X");
-    gStyle->SetLabelFont(62,     "Y");
-
-    // titles
-    gStyle->SetTitleFillColor(kWhite);
-    gStyle->SetTitleBorderSize(0);
-    gStyle->SetTitleFont      (62, "");
-    gStyle->SetTitleOffset    (0.0, "");
-    gStyle->SetTitleH         (0.07);
-
-    gStyle->SetTitleFont      (62,   "X");
-    gStyle->SetTitleOffset    (1.1,  "X");
-
-    gStyle->SetTitleFont      (62,   "Y");
-    gStyle->SetTitleOffset    (1.8,  "Y");
-
-    // ticks
-    gStyle->SetTickLength(0.03);
-
-    // statistics box
-    gStyle->SetStatFont (62);
-    gStyle->SetStatColor(kWhite);
-    gStyle->SetStatH    (0.20);
-    gStyle->SetStatW    (0.20);
-    gStyle->SetStatX    (0.965);
-    gStyle->SetStatY    (0.90);
-
-    // palette
-    gStyle->SetPalette(1, 0);
-
-}
 
 // ---------------------------------------------------------
 void BCAux::DefaultToPDF(std::string& filename)
@@ -368,9 +282,6 @@ void BCAux::DrawKnowledgeUpdate(BCHistogramBase& prior, BCHistogramBase& posteri
     }
     trash.Put(h2_axes);
     h2_axes->SetStats(false);
-    h2_axes->GetXaxis()->SetNdivisions(508);
-    if (prior.GetDimension() > 1)
-        h2_axes->GetYaxis()->SetNdivisions(508);
     h2_axes->Draw();
 
     // turn off legends

--- a/src/BCEngineMCMC.cxx
+++ b/src/BCEngineMCMC.cxx
@@ -3086,7 +3086,6 @@ bool BCEngineMCMC::DrawParameterPlot(unsigned i0, unsigned npar, double interval
     legend->SetFillColor(kWhite);
     legend->SetNColumns(2);
     legend->SetTextAlign(12);
-    legend->SetTextFont(62);
     legend->SetTextSize(0.02 * gPad->GetWNDC());
 
     if (!x_i.empty()) {
@@ -3225,25 +3224,21 @@ bool BCEngineMCMC::PrintCorrelationMatrix(const std::string& filename) const
     double text_size = std::max<double>(0.005, 0.02 * std::min<double>(1., 5. / GetNVariables()));
 
     TLatex xlabel;
-    xlabel.SetTextFont(62);
     xlabel.SetTextSize(text_size);
     xlabel.SetTextAlign(22);
 
     TLatex ylabel;
-    ylabel.SetTextFont(62);
     ylabel.SetTextSize(text_size);
     ylabel.SetTextAlign(22);
     ylabel.SetTextAngle(90);
 
     TLatex corr_number;
-    corr_number.SetTextFont(62);
     corr_number.SetTextSize(text_size);
     corr_number.SetTextAlign(22);
 
     gStyle->SetPalette(54);
     gStyle->SetPaintTextFormat("+.2g");
     hist_corr.GetZaxis()->SetRangeUser(-1, 1);
-    hist_corr.GetZaxis()->SetLabelFont(62);
     hist_corr.GetZaxis()->SetDecimals(true);
     hist_corr.GetZaxis()->SetLabelSize(text_size);
     hist_corr.Draw("colz");
@@ -3343,14 +3338,12 @@ bool BCEngineMCMC::PrintCorrelationPlot(const std::string& filename, bool includ
     double marginright  = marginleft;
 
     TLatex ylabel;
-    ylabel.SetTextFont(62);
     ylabel.SetTextSize(5e-2 / I.size());
     ylabel.SetTextAlign(22);     // set to 32, if latex names too long
     ylabel.SetNDC();
     ylabel.SetTextAngle(90);     // set to 80, if latex names too long
 
     TLatex xlabel;
-    xlabel.SetTextFont(62);
     xlabel.SetTextSize(5e-2 / I.size());
     xlabel.SetTextAlign(22);     // set to 12, if latex names too long
     xlabel.SetNDC();
@@ -3358,7 +3351,6 @@ bool BCEngineMCMC::PrintCorrelationPlot(const std::string& filename, bool includ
 
     // Box + Text for empty squares:
     TText text_na;
-    text_na.SetTextFont(42);
     text_na.SetTextAlign(22);
     text_na.SetTextSize(8e-1 / I.size());
     text_na.SetTextColor(kGray);

--- a/src/BCH2D.cxx
+++ b/src/BCH2D.cxx
@@ -96,6 +96,9 @@ void BCH2D::DrawBands(const std::string& options)
         return;
     }
 
+    if (fNBands == 0)
+        return;
+
     std::vector<double> intervals = fIntervals;
     CheckIntervals(intervals);
 

--- a/src/BCHistogramBase.cxx
+++ b/src/BCHistogramBase.cxx
@@ -67,7 +67,6 @@ BCHistogramBase::BCHistogramBase(const TH1* const hist, int dimension)
     fLegend.SetBorderSize(0);
     fLegend.SetFillColor(kWhite);
     fLegend.SetTextAlign(12);
-    fLegend.SetTextFont(62);
     fLegend.SetTextSize(0.03);
 
     fIntervals = DefaultIntervals();
@@ -221,13 +220,6 @@ void BCHistogramBase::SetHistogram(const TH1* const hist)
         fLocalMode.push_back(GetHistogram()->GetYaxis()->GetBinCenter(by));
     if (bz > 0)
         fLocalMode.push_back(GetHistogram()->GetZaxis()->GetBinCenter(bz));
-
-    GetHistogram()->GetXaxis()->SetNdivisions(508);
-    // Set Y title, if 1D
-    // if (GetHistogram()->GetDimension()==1 and strlen(GetHistogram()->GetYaxis()->GetTitle())==0)
-    //  GetHistogram()->SetYTitle(TString::Format("P(%s|Data)",GetHistogram()->GetXaxis()->GetTitle()));
-    if (GetHistogram()->GetDimension() > 1)
-        GetHistogram()->GetYaxis()->SetNdivisions(508);
 }
 
 // ---------------------------------------------------------

--- a/src/BCHistogramBase.cxx
+++ b/src/BCHistogramBase.cxx
@@ -695,14 +695,14 @@ void BCHistogramBase::DrawMean()
 double BCHistogramBase::ResizeLegend()
 {
 #if ROOTVERSION >= 6000000
-    fLegend.SetX1(gPad->GetLeftMargin());
+    fLegend.SetX1(gPad->GetLeftMargin() + (1 - gPad->GetRightMargin() - gPad->GetLeftMargin()) * 10e-2);
     fLegend.SetX2(1 - gPad->GetRightMargin());
     fLegend.SetY1(1 - gPad->GetTopMargin() - fLegend.GetTextSize()*fLegend.GetNRows());
     fLegend.SetY2(1 - gPad->GetTopMargin());
     fLegend.SetColumnSeparation(0.0);
     return fLegend.GetY1();
 #else
-    fLegend.SetX1NDC(gPad->GetLeftMargin());
+    fLegend.SetX1NDC(gPad->GetLeftMargin() + (1 - gPad->GetRightMargin() - gPad->GetLeftMargin()) * 10e-2);
     fLegend.SetX2NDC(1 - gPad->GetRightMargin());
     fLegend.SetY1NDC(1 - gPad->GetTopMargin() - fLegend.GetTextSize()*fLegend.GetNRows());
     fLegend.SetY2NDC(1 - gPad->GetTopMargin());

--- a/src/BCModel.cxx
+++ b/src/BCModel.cxx
@@ -253,6 +253,7 @@ BCH1D BCModel::GetPrior(unsigned index)
             if (const_prior) {
                 prior.SetLocalMode((unsigned)0, GetParameter(index).GetRangeCenter());
                 prior.SetNBands(0);
+                prior.SetDrawLocalMode(0);
             }
         }
     }
@@ -305,8 +306,13 @@ BCH2D BCModel::GetPrior(unsigned index1, unsigned index2)
             else if (!const_prior1 && const_prior2)
                 title += " (flat in " + fPriorModel->GetVariable(index2).GetLatexName() + ")";
             else if (const_prior1 && const_prior2) {
-                title += " (both flat)";
+                title += " (flat in both "
+                         + fPriorModel->GetVariable(index1).GetLatexName()
+                         + " and "
+                         + fPriorModel->GetVariable(index2).GetLatexName()
+                         + ")";
                 prior.SetNBands(0);
+                prior.SetDrawLocalMode(false);
             }
         }
     }
@@ -366,6 +372,7 @@ unsigned BCModel::PrintKnowledgeUpdatePlots(const std::string& filename, unsigne
         if (prior.GetNBands() == 0) {
             prior.CopyOptions(fBCH1DPriorDrawingOptions);
             prior.SetNBands(0);
+            prior.SetDrawLocalMode(false);
         } else
             prior.CopyOptions(fBCH1DPriorDrawingOptions);
         posterior.CopyOptions(fBCH1DPosteriorDrawingOptions);
@@ -387,6 +394,7 @@ unsigned BCModel::PrintKnowledgeUpdatePlots(const std::string& filename, unsigne
         if (prior.GetNBands() == 0) {
             prior.CopyOptions(fBCH2DPriorDrawingOptions);
             prior.SetNBands(0);
+            prior.SetDrawLocalMode(false);
         } else
             prior.CopyOptions(fBCH2DPriorDrawingOptions);
         posterior.CopyOptions(fBCH2DPosteriorDrawingOptions);

--- a/tools/Main1Template.cxx
+++ b/tools/Main1Template.cxx
@@ -6,15 +6,11 @@
 // ***************************************************************
 
 #include <BAT/BCLog.h>
-#include <BAT/BCAux.h>
 
 #include "((MODEL)).h"
 
 int main()
 {
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 

--- a/tools/Main2Template.cxx
+++ b/tools/Main2Template.cxx
@@ -6,13 +6,9 @@
 // ***************************************************************
 
 #include <BAT/BCLog.h>
-#include <BAT/BCAux.h>
 
 int main()
 {
-    // set nicer style for drawing than the ROOT default
-    BCAux::SetStyle();
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 


### PR DESCRIPTION
Originally `BCAux::SetStyle()` was created to fix the problem of ROOT's horrendously ugly default color scheme. ROOT corrected their default style long ago (well before the minimum version we now require), so most of the cosmetic changes of `SetStyle()` are no longer necessary. What does remain is some settings of tick-mark length, font, margins and offsets. I don't think BAT's choices are any better than ROOT's default. And by making font choices inside the code, we override the user's ability to change it through `gStyle`.

So I have moved all of our style overriding. We now use defaults of the system (ROOT's or a users set through any global option setting). I think the plots look still fine with the ROOT defaults.