### PR TITLE
using default behavior for clarity in examples

### DIFF
--- a/examples/advanced/mtf/systematics/runSystematics.cxx
+++ b/examples/advanced/mtf/systematics/runSystematics.cxx
@@ -58,10 +58,6 @@ int main()
     // create new fitter object
     BCMTF m;
 
-
-    // set Metropolis as marginalization method
-    m.SetMarginalizationMethod(BCIntegrate::kMargMetropolis);
-
     // set the required precision of the MCMC (kLow, kQuick, kMedium, kHigh)
     // the higher the precision the longer the MCMC run
     m.SetPrecision(BCEngineMCMC::kQuick);
@@ -107,10 +103,10 @@ int main()
     m.GetParameter("systematic2").SetPrior(new BCGaussianPrior(0., 1.));
 
     // run MCMC
-    m.MarginalizeAll();
+    m.MarginalizeAll(BCIntegrate::kMargMetropolis);
 
     // find global mode
-    m.FindMode(m.GetBestFitParameters());
+    m.FindMode();
 
     // print all marginalized distributions
     m.PrintAllMarginalized("marginalized.pdf");

--- a/examples/advanced/polynomialFit/asymmErrorsFitterExample.cxx
+++ b/examples/advanced/polynomialFit/asymmErrorsFitterExample.cxx
@@ -92,7 +92,7 @@ int main()
     for (unsigned i = 0; i < mgr.GetNModels(); ++i) {
         BCModel* m = mgr.GetModel(i);
         // find mode, starting from global mode found by marginalizing
-        m->FindMode(m->GetBestFitParameters());
+        m->FindMode();
         // write distrubutions to .root file
         m->WriteMarginalizedDistributions(m->GetSafeName() + "_plots.root", "RECREATE");
         // write distributions to .pdf file

--- a/examples/advanced/referenceCounting/runReferenceCounting.cxx
+++ b/examples/advanced/referenceCounting/runReferenceCounting.cxx
@@ -41,7 +41,7 @@ int main()
     m.MarginalizeAll(BCIntegrate::kMargMetropolis);
 
     // perform minimization with Minuit
-    m.FindMode(m.GetBestFitParameters());
+    m.FindMode();
 
     // draw all marginalized distributions into a pdf file
     m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");

--- a/examples/advanced/trialFunction/runTrialFunction.cxx
+++ b/examples/advanced/trialFunction/runTrialFunction.cxx
@@ -4,15 +4,11 @@
 
 int main()
 {
-
     // open log file
     BCLog::OpenLog("log.txt", BCLog::detail, BCLog::detail);
 
     // create new GaussModel object
     GaussModel m("Gauss Model");
-
-    // set marginalization method
-    m.SetMarginalizationMethod(BCIntegrate::kMargMetropolis);
 
     // set MCMC precision
     m.SetPrecision(BCEngineMCMC::kMedium);
@@ -20,16 +16,13 @@ int main()
     // set scale factor upper limit
     m.SetScaleFactorUpperLimit(10);
 
-    // run MCMC and marginalize posterior wrt. all parameters
-    // and all combinations of two parameters
-    m.MarginalizeAll();
+    // run MCMC and marginalize posterior
+    m.MarginalizeAll(BCIntegrate::kMargMetropolis);
 
-    // if MCMC was run before (MarginalizeAll()) it is
-    // possible to use the mode found by MCMC as
-    // starting point of Minuit minimization
-    m.FindMode(m.GetBestFitParameters());
+    // Optimize, starting from best fit point found by the marginalization
+    m.FindMode();
 
-    // draw all marginalized distributions into a PostScript file
+    // draw all marginalized distributions into a file
     m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");
 
     // print results of the analysis to the log
@@ -39,6 +32,5 @@ int main()
     BCLog::CloseLog();
 
     return 0;
-
 }
 

--- a/examples/basic/binomial/runEfficiency.cxx
+++ b/examples/basic/binomial/runEfficiency.cxx
@@ -14,7 +14,7 @@ int main()
     m.MarginalizeAll();
 
     // find mode starting from the best fit parameters
-    m.FindMode(m.GetBestFitParameters());
+    m.FindMode();
 
     // draw all marginalized distributions into a pdf file
     m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");

--- a/examples/basic/combination1d/runCombineGaussians.cxx
+++ b/examples/basic/combination1d/runCombineGaussians.cxx
@@ -17,7 +17,7 @@ int main()
     m.MarginalizeAll();
 
     // find mode
-    m.FindMode(m.GetBestFitParameters());
+    m.FindMode();
 
     // draw all marginalized distributions into a PostScript file
     m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");

--- a/examples/basic/combination2d/runCombineGaussians.cxx
+++ b/examples/basic/combination2d/runCombineGaussians.cxx
@@ -17,7 +17,7 @@ int main()
     m.MarginalizeAll();
 
     // find mode
-    m.FindMode(m.GetBestFitParameters());
+    m.FindMode();
 
     // draw all marginalized distributions into a PostScript file
     m.PrintAllMarginalized("CombinationModel_plots.pdf");

--- a/examples/basic/errorPropagation/runErrorPropagation.cxx
+++ b/examples/basic/errorPropagation/runErrorPropagation.cxx
@@ -10,17 +10,14 @@ int main()
     // create new RatioModel object
     RatioModel m("Ratio Model");
 
-    // set Metropolis as marginalization method
-    m.SetMarginalizationMethod(BCIntegrate::kMargMetropolis);
-
     // set precision
     m.SetPrecision(BCEngineMCMC::kMedium);
 
     // run the MCMC and marginalize w.r.t. to all parameters
-    m.MarginalizeAll();
+    m.MarginalizeAll(BCIntegrate::kMargMetropolis);
 
     // find mode using the best fit parameters as start values
-    m.FindMode(m.GetBestFitParameters());
+    m.FindMode();
 
     // draw all marginalized distributions into a PostScript file
     m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");

--- a/examples/basic/poisson/runPoissonCounting.cxx
+++ b/examples/basic/poisson/runPoissonCounting.cxx
@@ -18,7 +18,7 @@ int main()
     m.MarginalizeAll();
 
     // find mode starting from the best fit parameters
-    m.FindMode(m.GetBestFitParameters());
+    m.FindMode();
 
     // draw all marginalized distributions into a PDF file
     m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");

--- a/examples/basic/rootOutput/runRootOutput.cxx
+++ b/examples/basic/rootOutput/runRootOutput.cxx
@@ -29,10 +29,8 @@ int main()
     m.SetNIterationsRun(100000);
     m.MarginalizeAll();
 
-    // if MCMC was run before (MarginalizeAll()) it is
-    // possible to use the mode found by MCMC as
-    // starting point of Minuit minimization
-    m.FindMode(m.GetBestFitParameters());
+    // find the mode, starting from best fit point found by the MCMC
+    m.FindMode();
 
     // draw all marginalized distributions into a PostScript file
     m.PrintAllMarginalized(m.GetSafeName() + "_plots.pdf");


### PR DESCRIPTION
Changing `m.FindMode(m.GetBestFitParameters())` to `m.FindMode()` in examples since this is the default behavior anyway.