### PR TITLE
BCEngineMCMC.cxx: added indication of the direction of the R value update 

### DIFF
--- a/src/BCEngineMCMC.cxx
+++ b/src/BCEngineMCMC.cxx
@@ -1731,6 +1731,8 @@ bool BCEngineMCMC::MetropolisPreRun()
 
     unsigned nIterationsPreRunCheck = fMCMCNIterationsPreRunCheck;
 
+    std::vector<double> fMCMCRValueParametersLast = fMCMCRValueParameters;
+
     // autosave every 10 checks
     if (fMCMCTree) {
         fMCMCTree->AutoSave("SaveSelf");
@@ -1913,10 +1915,18 @@ bool BCEngineMCMC::MetropolisPreRun()
                     if (GetParameter(p).Fixed())
                         continue;
 
+                    std::string updateRValue = "";
+                    if(fMCMCRValueParameters[p] > fMCMCRValueParametersLast[p])
+                        updateRValue = "+";
+                    else if(fMCMCRValueParameters[p] < fMCMCRValueParametersLast[p])
+                        updateRValue = "-";
+                    else
+                        updateRValue = "=";
+
                     if (fMCMCRValueParameters[p] < fMCMCRValueParametersCriterion)
                         BCLog::OutDetail(Form("         %-*s :  %.03f", fParameters.MaxNameLength(), GetParameter(p).GetName().data(), fMCMCRValueParameters[p]));
                     else if (std::isfinite(fMCMCRValueParameters[p]))
-                        BCLog::OutDetail(Form("         %-*s :  %.03f <-- Greater than threshold", fParameters.MaxNameLength(), GetParameter(p).GetName().data(), fMCMCRValueParameters[p]));
+                        BCLog::OutDetail(Form("         %-*s :  %.03f [%s] <-- Greater than threshold", fParameters.MaxNameLength(), GetParameter(p).GetName().data(), fMCMCRValueParameters[p], updateRValue.c_str()));
                     else
                         BCLog::OutDetail(Form("         %-*s :  error in calculation", fParameters.MaxNameLength(), GetParameter(p).GetName().data()));
                 }
@@ -1925,6 +1935,8 @@ bool BCEngineMCMC::MetropolisPreRun()
         if (fMCMCTree && nChecks % 10 == 0) {
             fMCMCTree->AutoSave("SaveSelf");
         }
+
+        fMCMCRValueParametersLast = fMCMCRValueParameters;
 
         ++nChecks;              // increase number of checks made
 


### PR DESCRIPTION
This pull request adds tracking and printing of the update direction of the R-value between prerun iterations. 

Example:

```
Detail  :      * Convergence status: Set of 4 Markov chains did not converge after 4000 iterations.
Detail  :        - Parameter :  R-Value
Detail  :          alpha1  :  1.042
Detail  :          alpha2  :  1.015
Detail  :          n1      :  1.391 [+] <-- Greater than threshold
Detail  :          n2      :  1.138 [+] <-- Greater than threshold
Detail  :          xbar1   :  1.255 [-] <-- Greater than threshold
Detail  :          xbarG   :  3.521 [+] <-- Greater than threshold
Detail  :          sigma1  :  1.959 [+] <-- Greater than threshold
Detail  :          sigmaG  :  4.611 [-] <-- Greater than threshold
Detail  :          fsig    :  1.205 [-] <-- Greater than threshold
Detail  :          c1      :  1.772 [-] <-- Greater than threshold
Detail  :          fcomb   :  1.007
Detail  :      * Convergence status: Set of 4 Markov chains did not converge after 4500 iterations.
Detail  :        - Parameter :  R-Value
Detail  :          alpha1  :  1.039
Detail  :          alpha2  :  1.013
Detail  :          n1      :  1.450 [+] <-- Greater than threshold
Detail  :          n2      :  1.163 [+] <-- Greater than threshold
Detail  :          xbar1   :  1.248 [-] <-- Greater than threshold
Detail  :          xbarG   :  3.548 [+] <-- Greater than threshold
Detail  :          sigma1  :  1.992 [+] <-- Greater than threshold
Detail  :          sigmaG  :  4.004 [-] <-- Greater than threshold
Detail  :          fsig    :  1.195 [-] <-- Greater than threshold
Detail  :          c1      :  1.720 [-] <-- Greater than threshold
Detail  :          fcomb   :  1.005
```
