### PR TITLE
Fix compilation with C++17 (Clang) #325

### DIFF
--- a/src/BCAux.cxx
+++ b/src/BCAux.cxx
@@ -111,7 +111,10 @@ void BCAux::MakeFinite(double& xmin, double& xmax)
 std::string BCAux::SafeName(const std::string& name)
 {
     std::string res(name);
-    res.erase(std::remove_if(res.begin(), res.end(), [](char c){ return !BCAux::AllowedCharacter(c); }), res.end());
+    for (std::string::iterator it = res.begin(); it != res.end(); ) {
+        if (!BCAux::AllowedCharacter(*it)) res.erase(it);
+        else it++;
+    }
     return res;
 }
 

--- a/src/BCAux.cxx
+++ b/src/BCAux.cxx
@@ -112,8 +112,10 @@ std::string BCAux::SafeName(const std::string& name)
 {
     std::string res(name);
     for (std::string::iterator it = res.begin(); it != res.end(); ) {
-        if (!BCAux::AllowedCharacter(*it)) res.erase(it);
-        else it++;
+        if (!BCAux::AllowedCharacter(*it))
+            res.erase(it);
+        else
+            it++;
     }
     return res;
 }

--- a/src/BCAux.cxx
+++ b/src/BCAux.cxx
@@ -111,7 +111,7 @@ void BCAux::MakeFinite(double& xmin, double& xmax)
 std::string BCAux::SafeName(const std::string& name)
 {
     std::string res(name);
-    res.erase(std::remove_if(res.begin(), res.end(), std::not1(std::ptr_fun(BCAux::AllowedCharacter))), res.end());
+    res.erase(std::remove_if(res.begin(), res.end(), [](char c){ return !BCAux::AllowedCharacter(c); }), res.end());
     return res;
 }
 


### PR DESCRIPTION
Replace deprecated `std::ptr_fun` with lambda function. Makes BAT compilable with `-std=c++17` on my Mac.