### PR TITLE
Fix warning when compiling with c++14 in debug mode

### DIFF
--- a/BAT/BCH1D.h
+++ b/BAT/BCH1D.h
@@ -60,10 +60,6 @@ public:
     BCH1D(const TH1* const hist = 0);
 
     /**
-     * Copy constructor. */
-    BCH1D(const BCH1D& other);
-
-    /**
      * The default destructor. */
     virtual ~BCH1D() {};
 

--- a/BAT/BCH2D.h
+++ b/BAT/BCH2D.h
@@ -82,10 +82,6 @@ public:
     BCH2D(const TH2* const h = 0);
 
     /**
-     * Copy constuctor. */
-    BCH2D(const BCH2D& other);
-
-    /**
      * The default destructor. */
     virtual ~BCH2D() {};
 

--- a/src/BCH1D.cxx
+++ b/src/BCH1D.cxx
@@ -40,13 +40,6 @@ BCH1D::BCH1D(const TH1* const hist)
 }
 
 // ---------------------------------------------------------
-BCH1D::BCH1D(const BCH1D& other)
-    : BCHistogramBase(other)
-{
-    CopyOptions(other);
-}
-
-// ---------------------------------------------------------
 void BCH1D::CopyOptions(const BCH1D& other)
 {
     BCHistogramBase::CopyOptions(other);

--- a/src/BCH2D.cxx
+++ b/src/BCH2D.cxx
@@ -42,16 +42,10 @@ BCH2D::BCH2D(const TH2* const h)
 }
 
 // ---------------------------------------------------------
-BCH2D::BCH2D(const BCH2D& other)
-    : BCHistogramBase(other)
-{
-    CopyOptions(other);
-}
-
-// ---------------------------------------------------------
 void BCH2D::CopyOptions(const BCH2D& other)
 {
     BCHistogramBase::CopyOptions(other);
+    fLogz = other.fLogz;
     fBandType = other.fBandType;
     fDrawProfileX = other.fDrawProfileX;
     fProfileXType = other.fProfileXType;


### PR DESCRIPTION
- remove useless explicit copy ctor in BCH1D* and rely on safer default one
- fix missing member in CopyOptions()