### PR TITLE
Improvements to BCModelManager

### DIFF
--- a/BAT/BCModelManager.h
+++ b/BAT/BCModelManager.h
@@ -73,6 +73,11 @@ public:
     { return fModels.size(); }
 
     /**
+     * @return vector of models */
+    std::vector<BCModel*> GetModels()
+    { return fModels; }
+    
+    /**
      * Returns the BCModel at a certain index of this BCModelManager.
      * @param index The index of the model in the BCModelManager.
      * @return The BCModel at the index. */

--- a/BAT/BCModelManager.h
+++ b/BAT/BCModelManager.h
@@ -167,7 +167,7 @@ public:
      * Adds a model to the container.
      * @param model The model
      * @param prior_probability The model's a-priori probability */
-    void AddModel(BCModel* model, double prior_probability = 0.);
+    void AddModel(BCModel* model, double prior_probability = 1.);
 
     /**
      * Calculates the normalization of the likelihood for each model in


### PR DESCRIPTION
1. Defaulted prior for a model to 1. This allows one to add multiple models, all with equal weight, without specifying the weights as they are added. This allows for more expandable code that uses `BCModelManager`.

2. Give access to the vector of `BCModel`'s stored in the manager.