### PR TITLE
BCHistogramBase resize bugfix

### DIFF
--- a/BAT/BCModelManager.h
+++ b/BAT/BCModelManager.h
@@ -73,6 +73,11 @@ public:
     { return fModels.size(); }
 
     /**
+     * @return vector of models */
+    std::vector<BCModel*> GetModels()
+    { return fModels; }
+    
+    /**
      * Returns the BCModel at a certain index of this BCModelManager.
      * @param index The index of the model in the BCModelManager.
      * @return The BCModel at the index. */
@@ -84,6 +89,18 @@ public:
      * @return The data set. */
     BCDataSet* GetDataSet()
     { return fDataSet; };
+
+    /**
+     * Returns the prior probabilities
+     * @return vector of prior probabilities */
+    std::vector<double> GetPriorProbability() const
+    { return fAPrioriProbability; }
+
+    /**
+     * Returns the posterior probabilities
+     * @return vector of posterior probabilities */
+    std::vector<double> GetPosteriorProbability() const
+    { return fAPosterioriProbability; }
 
     /** @} */
 
@@ -155,7 +172,7 @@ public:
      * Adds a model to the container.
      * @param model The model
      * @param prior_probability The model's a-priori probability */
-    void AddModel(BCModel* model, double prior_probability = 0.);
+    void AddModel(BCModel* model, double prior_probability = 1.);
 
     /**
      * Calculates the normalization of the likelihood for each model in

--- a/src/BCHistogramBase.cxx
+++ b/src/BCHistogramBase.cxx
@@ -743,8 +743,6 @@ void BCHistogramBase::DrawLegend()
         ymax = pow(10, ymax);
     }
 
-    fHistogram->GetYaxis()->SetRangeUser(ymin, ymax * (1.15 + fLegend.GetTextSize()*fLegend.GetNRows()) * 1.05);
-
     gPad->SetTopMargin(0.02);
 
     double y1ndc = ResizeLegend();

--- a/src/BCModelManager.cxx
+++ b/src/BCModelManager.cxx
@@ -273,10 +273,12 @@ void BCModelManager::PrintSummary() const
     for (unsigned i = 0; i < fModels.size(); ++i)
         fModels[i]->PrintSummary();
 
-    BCLog::OutSummary(" - Data:");
-    BCLog::OutSummary("");
-    BCLog::OutSummary(Form("     Number of entries: %u", fDataSet->GetNDataPoints()));
-    BCLog::OutSummary("");
+    if (fDataSet) {
+        BCLog::OutSummary(" - Data:");
+        BCLog::OutSummary("");
+        BCLog::OutSummary(Form("     Number of entries: %u", fDataSet->GetNDataPoints()));
+        BCLog::OutSummary("");
+    }
 
     PrintModelComparisonSummary();
 }


### PR DESCRIPTION
Addresses #338.

Removes resizing completely since it seems entirely unnecessary.