### PR TITLE
Fix detection of Cuba version when modern compilers are used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ elif test "$with_cuba" = "no"; then
 elif test "$with_cuba" = "download"; then
   use_cuba=yes
 
-  cuba_version_default=4.2
+  cuba_version_default=4.2.2
   local_cuba_dir="`pwd`/external/cuba-${cuba_version_default}"
   cuba_url="http://www.feynarts.de/cuba/Cuba-${cuba_version_default}.tar.gz"
 

--- a/configure.ac
+++ b/configure.ac
@@ -236,10 +236,10 @@ if test "x$use_cuba" != xno; then
   {
     int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew;
     double epsrel, epsabs, flatness;
-    int *spin, *nregions, *fail, *neval;
+    int *nregions, *fail, *neval;
     double *integral, *error, *prob;
     const char *statefile = "";
-    void *userdata;
+    void *userdata, *spin;
     Suave(ndim, ncomp, &integrand, userdata, nvec,
         epsrel, epsabs, flags, seed, mineval, maxeval,
         nnew, flatness, statefile,
@@ -266,10 +266,10 @@ if test "x$use_cuba" != xno; then
   {
     int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, nmin;
     double epsrel, epsabs, flatness;
-    int *spin, *nregions, *fail, *neval;
+    int *nregions, *fail, *neval;
     double *integral, *error, *prob;
     const char *statefile = "";
-    void *userdata;
+    void *userdata, *spin;
     Suave(ndim, ncomp, &integrand, userdata, nvec,
         epsrel, epsabs, flags, seed, mineval, maxeval, nnew,
         nmin, /* nmin added in 4.1 */

--- a/configure.ac
+++ b/configure.ac
@@ -213,7 +213,7 @@ if test "x$use_cuba" != xno; then
     const char * statefile = "";
     void * userdata;
     Suave(ndim, ncomp, &integrand, userdata, nvec,
-        epsrel, ebsabs, flags, seed, mineval, maxeval,
+        epsrel, epsabs, flags, seed, mineval, maxeval,
         nnew, flatness, statefile,
         nregions, neval, fail, integral, error, prob);
 
@@ -241,7 +241,7 @@ if test "x$use_cuba" != xno; then
     const char * statefile = "";
     void * userdata;
     Suave(ndim, ncomp, &integrand, userdata, nvec,
-        epsrel, ebsabs, flags, seed, mineval, maxeval,
+        epsrel, epsabs, flags, seed, mineval, maxeval,
         nnew, flatness, statefile,
         spin, /*spin was added in 4.0 */
         nregions, neval, fail, integral, error, prob);

--- a/configure.ac
+++ b/configure.ac
@@ -234,12 +234,12 @@ if test "x$use_cuba" != xno; then
 
   int main()
   {
-    int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, spin;
+    int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew;
     double epsrel, epsabs, flatness;
-    int * nregions, *fail, *neval;
-    double * integral, *error, *prob;
-    const char * statefile = "";
-    void * userdata;
+    int *spin, *nregions, *fail, *neval;
+    double *integral, *error, *prob;
+    const char *statefile = "";
+    void *userdata;
     Suave(ndim, ncomp, &integrand, userdata, nvec,
         epsrel, epsabs, flags, seed, mineval, maxeval,
         nnew, flatness, statefile,
@@ -264,12 +264,12 @@ if test "x$use_cuba" != xno; then
 
   int main()
   {
-    int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, nmin, spin;
+    int ndim, ncomp, nvec, flags, seed, mineval, maxeval, nnew, nmin;
     double epsrel, epsabs, flatness;
-    int * nregions, *fail, *neval;
-    double * integral, *error, *prob;
-    const char * statefile = "";
-    void * userdata;
+    int *spin, *nregions, *fail, *neval;
+    double *integral, *error, *prob;
+    const char *statefile = "";
+    void *userdata;
     Suave(ndim, ncomp, &integrand, userdata, nvec,
         epsrel, epsabs, flags, seed, mineval, maxeval, nnew,
         nmin, /* nmin added in 4.1 */


### PR DESCRIPTION
I recently found I could not configure BAT anymore with Cuba enabled: `./configure --with-cuba=download` was failing with BAT unable to detect the correct Cuba version (`This version of cuba does not match the interface of the supported version 3.3 or later`).

I found out an issue in `configure.ac`, where the wrong type was used for `spin` (`int` instead of `*int`), and apparently modern compilers like gcc 14 are less forgiving than past ones.

This PR fixes the issue, since now I manage to configure BAT with Cuba and compile it without problems.

(Tested on EL9 with gcc 14 and both Cuba 4.2 and 4.2.2.)